### PR TITLE
SetMulticastTTL, SetMulticastLoopback enabled in UDP for TizenRT

### DIFF
--- a/src/modules/iotjs_module_udp.c
+++ b/src/modules/iotjs_module_udp.c
@@ -376,7 +376,7 @@ JHANDLER_FUNCTION(SetTTL) {
 
 
 JHANDLER_FUNCTION(SetMulticastTTL) {
-#if !defined(__NUTTX__) && !defined(__TIZENRT__)
+#if !defined(__NUTTX__)
   IOTJS_UV_SET_SOCKOPT(uv_udp_set_multicast_ttl);
 #else
   IOTJS_ASSERT(!"Not implemented");
@@ -387,7 +387,7 @@ JHANDLER_FUNCTION(SetMulticastTTL) {
 
 
 JHANDLER_FUNCTION(SetMulticastLoopback) {
-#if !defined(__NUTTX__) && !defined(__TIZENRT__)
+#if !defined(__NUTTX__)
   IOTJS_UV_SET_SOCKOPT(uv_udp_set_multicast_loop);
 #else
   IOTJS_ASSERT(!"Not implemented");


### PR DESCRIPTION
1. SetMulticastTTL and SetMulticastLoopback functions in UDP module
   were enabled for TizenRT.
2. The updated libtuv supports TTL related features.

IoT.js-DCO-1.0-Signed-off-by: Piotr Marcinkiewicz p.marcinkiew@samsung.com