### PR TITLE
Workaround for string missing terminator

### DIFF
--- a/src/iotjs_string.c
+++ b/src/iotjs_string.c
@@ -40,8 +40,9 @@ iotjs_string_t iotjs_string_create_with_size(const char* data, size_t size) {
 
   if (size > 0) {
     IOTJS_ASSERT(data != NULL);
-    _this->data = iotjs_buffer_allocate(size);
+    _this->data = iotjs_buffer_allocate(size + 1);
     memcpy(_this->data, data, size);
+    *((char*)_this->data + size) = 0;
   } else {
     _this->data = NULL;
   }
@@ -58,7 +59,10 @@ iotjs_string_t iotjs_string_create_with_buffer(char* buffer, size_t size) {
 
   if (size > 0) {
     IOTJS_ASSERT(buffer != NULL);
-    _this->data = buffer;
+    _this->data = iotjs_buffer_allocate(size + 1);
+    memcpy(_this->data, buffer, size);
+    *((char*)_this->data + size) = 0;
+    iotjs_buffer_release(buffer);
   } else {
     _this->data = NULL;
   }
@@ -105,13 +109,14 @@ void iotjs_string_append(iotjs_string_t* str, const char* data, size_t size) {
   }
 
   if (_this->data != NULL) {
-    _this->data = iotjs_buffer_reallocate(_this->data, _this->size + size);
+    _this->data = iotjs_buffer_reallocate(_this->data, _this->size + size + 1);
   } else {
     IOTJS_ASSERT(_this->size == 0);
-    _this->data = iotjs_buffer_allocate(size);
+    _this->data = iotjs_buffer_allocate(size + 1);
   }
 
   memcpy(_this->data + _this->size, data, size);
+  *((char*)_this->data + _this->size + size) = 0;
   _this->size += size;
 }
 

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -464,15 +464,14 @@ JHANDLER_FUNCTION(ToHexString) {
   const char* data = iotjs_bufferwrap_buffer(buffer_wrap);
 
   char* buffer = iotjs_buffer_allocate(length * 2);
-  iotjs_string_t str = iotjs_string_create_with_buffer(buffer, length * 2);
+  char* pc = buffer;
 
   for (size_t i = 0; i < length; i++) {
-    memcpy(buffer, &"0123456789abcdef"[data[i] >> 4 & 0xF], 1);
-    buffer++;
-    memcpy(buffer, &"0123456789abcdef"[data[i] >> 0 & 0xF], 1);
-    buffer++;
+    *pc++ = "0123456789abcdef"[data[i] >> 4 & 0xF];
+    *pc++ = "0123456789abcdef"[data[i] >> 0 & 0xF];
   }
 
+  iotjs_string_t str = iotjs_string_create_with_buffer(buffer, length * 2);
   iotjs_jhandler_return_string(jhandler, &str);
   iotjs_string_destroy(&str);
 }

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -10,7 +10,7 @@
     { "name": "test_console.js" },
     { "name": "test_dgram_1_server_1_client.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_dgram_1_server_n_clients.js", "skip": ["all"], "reason": "need to setup test environment" },
-    { "name": "test_dgram_address.js", "skip": ["all"], "reason": "need to setup test environment"  },
+    { "name": "test_dgram_address.js" },
     { "name": "test_dgram_broadcast.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_dgram_multicast_membership.js", "skip": ["all"], "reason": "need to setup test environment" },
     { "name": "test_dgram_multicast_set_multicast_loop.js", "skip": ["all"], "reason": "need to setup test environment" },


### PR DESCRIPTION
libtuv expects cstrings while UDP module was passing javascript strings without terminator, which caused libtuv functions to fail

this fixes `test_dgram_address.js`

IoT.js-DCO-1.0-Signed-off-by: Krzysztof Antoszek k.antoszek@samsung.com