### PR TITLE
Fix test_net_connection (#1199)

### DIFF
--- a/test/run_pass/test_net_connect.js
+++ b/test/run_pass/test_net_connect.js
@@ -20,10 +20,7 @@ var port = 5696;
 var msg = 'Hello IoT.js';
 
 var server = net.createServer({
-    allowHalfOpen: true,
-  },
-  function(socket) {
-    server.close();
+    allowHalfOpen: true
   }
 ).listen(port);
 
@@ -45,6 +42,7 @@ var socket = net.connect(port, host, function() {
 
   socket.on('end', function() {
     assert.equal(data, msg);
+    server.close();
   });
 
   socket.end(msg);


### PR DESCRIPTION
This fix closes the server in the test more clearly.

IoT.js-DCO-1.0-Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com