### PR TITLE
Fix memory leak on dns.getaddrinfo and tcp.onconnection (#1233)

### DIFF
--- a/src/modules/iotjs_module_dns.c
+++ b/src/modules/iotjs_module_dns.c
@@ -186,6 +186,7 @@ JHANDLER_FUNCTION(GetAddrInfo) {
   } else if (option == 6) {
     family = AF_INET6;
   } else {
+    iotjs_string_destroy(&hostname);
     JHANDLER_THROW(TYPE, "bad address family");
     return;
   }

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -387,6 +387,7 @@ static void OnConnection(uv_stream_t* handle, int status) {
 
     int err = uv_accept(handle, client_handle);
     if (err) {
+      iotjs_jargs_destroy(&args);
       return;
     }
 


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com