### PR TITLE
Enable es2015 in jerry-script

### DIFF
--- a/test/node/common.js
+++ b/test/node/common.js
@@ -359,7 +359,7 @@ if (global.ArrayBuffer) {
   knownGlobals.push(Uint32Array);
   knownGlobals.push(Float32Array);
   knownGlobals.push(Float64Array);
-  knownGlobals.push(DataView);
+  //knownGlobals.push(DataView); // this is not supported in iotjs
 }
 
 // Harmony features.

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -51,7 +51,7 @@
     { "name": "test_https_request_response.js", "timeout": 40, "skip": ["all"], "reason": "Implemented only for Tizen" },
     { "name": "test_https_timeout.js", "timeout": 40, "skip": ["all"], "reason": "Implemented only for Tizen" },
     { "name": "test_i2c.js", "skip": ["all"], "reason": "need to setup test environment" },
-    { "name": "test_iotjs_promise.js", "skip": ["all"], "reason": "es2015 is off by default" },
+    { "name": "test_iotjs_promise.js" },
     { "name": "test_module_cache.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_module_require.js", "skip": ["nuttx"], "reason": "not implemented for nuttx" },
     { "name": "test_net_1.js" },

--- a/tools/build.py
+++ b/tools/build.py
@@ -184,7 +184,7 @@ def init_options():
         help='Enable JerryScript heap statistics')
 
     parser.add_argument('--jerry-profile',
-        choices=['es5.1', 'es2015-subset'], default='es5.1',
+        choices=['es5.1', 'es2015-subset'], default='es2015-subset',
         help='Specify the profile for JerryScript: %(choices)s'
              ' (default: %(default)s)')
     parser.add_argument('--jerry-debugger',


### PR DESCRIPTION
Allows to run Promise tests (they pass)

IoT.js-DCO-1.0-Signed-off-by: Krzysztof Antoszek k.antoszek@samsung.com