### PR TITLE
Change 'iotjs_jval_t*' function parameters (#1213)

### DIFF
--- a/src/modules/iotjs_module_adc.c
+++ b/src/modules/iotjs_module_adc.c
@@ -21,13 +21,13 @@
 static JNativeInfoType this_module_native_info = {.free_cb = NULL };
 
 
-static iotjs_adc_t* iotjs_adc_instance_from_jval(const iotjs_jval_t* jadc);
+static iotjs_adc_t* iotjs_adc_instance_from_jval(const iotjs_jval_t jadc);
 
 
-static iotjs_adc_t* iotjs_adc_create(const iotjs_jval_t* jadc) {
+static iotjs_adc_t* iotjs_adc_create(const iotjs_jval_t jadc) {
   iotjs_adc_t* adc = IOTJS_ALLOC(iotjs_adc_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_adc_t, adc);
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jadc,
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, &jadc,
                                &this_module_native_info);
 
   return adc;
@@ -48,11 +48,11 @@ static void iotjs_adc_destroy(iotjs_adc_t* adc) {
 
 
 static iotjs_adc_reqwrap_t* iotjs_adc_reqwrap_create(
-    const iotjs_jval_t* jcallback, iotjs_adc_t* adc, AdcOp op) {
+    const iotjs_jval_t jcallback, iotjs_adc_t* adc, AdcOp op) {
   iotjs_adc_reqwrap_t* adc_reqwrap = IOTJS_ALLOC(iotjs_adc_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_adc_reqwrap_t, adc_reqwrap);
 
-  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
+  iotjs_reqwrap_initialize(&_this->reqwrap, &jcallback, (uv_req_t*)&_this->req);
 
   _this->req_data.op = op;
   _this->adc_instance = adc;
@@ -78,14 +78,14 @@ static uv_work_t* iotjs_adc_reqwrap_req(THIS) {
 }
 
 
-static const iotjs_jval_t* iotjs_adc_reqwrap_jcallback(THIS) {
+static iotjs_jval_t iotjs_adc_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_adc_reqwrap_t, adc_reqwrap);
-  return iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 
-static iotjs_adc_t* iotjs_adc_instance_from_jval(const iotjs_jval_t* jadc) {
-  uintptr_t handle = iotjs_jval_get_object_native_handle(jadc);
+static iotjs_adc_t* iotjs_adc_instance_from_jval(const iotjs_jval_t jadc) {
+  uintptr_t handle = iotjs_jval_get_object_native_handle(&jadc);
   return (iotjs_adc_t*)handle;
 }
 
@@ -153,8 +153,8 @@ static void iotjs_adc_after_work(uv_work_t* work_req, int status) {
     }
   }
 
-  const iotjs_jval_t* jcallback = iotjs_adc_reqwrap_jcallback(req_wrap);
-  iotjs_make_callback(jcallback, iotjs_jval_get_undefined(), &jargs);
+  const iotjs_jval_t jcallback = iotjs_adc_reqwrap_jcallback(req_wrap);
+  iotjs_make_callback(&jcallback, iotjs_jval_get_undefined(), &jargs);
 
   iotjs_jargs_destroy(&jargs);
 
@@ -206,7 +206,7 @@ JHANDLER_FUNCTION(AdcConstructor) {
   DJHANDLER_CHECK_THIS(object);
 
   // Create ADC object
-  const iotjs_jval_t* jadc = JHANDLER_GET_THIS(object);
+  const iotjs_jval_t jadc = *JHANDLER_GET_THIS(object);
   iotjs_adc_t* adc = iotjs_adc_create(jadc);
   IOTJS_ASSERT(adc == iotjs_adc_instance_from_jval(jadc));
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_adc_t, adc);
@@ -226,8 +226,8 @@ JHANDLER_FUNCTION(AdcConstructor) {
 #endif
 
   if (iotjs_jhandler_get_arg_length(jhandler) > 1) {
-    const iotjs_jval_t* jcallback = iotjs_jhandler_get_arg(jhandler, 1);
-    if (iotjs_jval_is_function(jcallback)) {
+    const iotjs_jval_t jcallback = *iotjs_jhandler_get_arg(jhandler, 1);
+    if (iotjs_jval_is_function(&jcallback)) {
       ADC_ASYNC(open, adc, jcallback, kAdcOpOpen);
     } else {
       JHANDLER_THROW(TYPE, "Bad arguments - callback should be Function");
@@ -236,7 +236,7 @@ JHANDLER_FUNCTION(AdcConstructor) {
   } else {
     iotjs_jval_t jdummycallback =
         iotjs_jval_create_function(&iotjs_jval_dummy_function);
-    ADC_ASYNC(open, adc, &jdummycallback, kAdcOpOpen);
+    ADC_ASYNC(open, adc, jdummycallback, kAdcOpOpen);
     iotjs_jval_destroy(&jdummycallback);
   }
 }
@@ -246,12 +246,12 @@ JHANDLER_FUNCTION(Read) {
   JHANDLER_DECLARE_THIS_PTR(adc, adc);
   DJHANDLER_CHECK_ARG_IF_EXIST(0, function);
 
-  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
+  iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
 
   if (jerry_value_is_null(jcallback)) {
     JHANDLER_THROW(TYPE, "Bad arguments - callback required");
   } else {
-    ADC_ASYNC(read, adc, &jcallback, kAdcOpRead);
+    ADC_ASYNC(read, adc, jcallback, kAdcOpRead);
   }
 }
 
@@ -275,10 +275,10 @@ JHANDLER_FUNCTION(Close) {
   if (jerry_value_is_null(jcallback)) {
     iotjs_jval_t jdummycallback =
         iotjs_jval_create_function(&iotjs_jval_dummy_function);
-    ADC_ASYNC(close, adc, &jdummycallback, kAdcOpClose);
+    ADC_ASYNC(close, adc, jdummycallback, kAdcOpClose);
     iotjs_jval_destroy(&jdummycallback);
   } else {
-    ADC_ASYNC(close, adc, &jcallback, kAdcOpClose);
+    ADC_ASYNC(close, adc, jcallback, kAdcOpClose);
   }
 
   iotjs_jhandler_return_null(jhandler);

--- a/src/modules/iotjs_module_blehcisocket.c
+++ b/src/modules/iotjs_module_blehcisocket.c
@@ -48,11 +48,11 @@
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(blehcisocket);
 
 
-iotjs_blehcisocket_t* iotjs_blehcisocket_create(const iotjs_jval_t* jble) {
+iotjs_blehcisocket_t* iotjs_blehcisocket_create(iotjs_jval_t jble) {
   THIS = IOTJS_ALLOC(iotjs_blehcisocket_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_blehcisocket_t, blehcisocket);
 
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jble,
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, &jble,
                                &this_module_native_info);
 
   iotjs_blehcisocket_initialize(blehcisocket);
@@ -61,9 +61,8 @@ iotjs_blehcisocket_t* iotjs_blehcisocket_create(const iotjs_jval_t* jble) {
 }
 
 
-iotjs_blehcisocket_t* iotjs_blehcisocket_instance_from_jval(
-    const iotjs_jval_t* jble) {
-  iotjs_jobjectwrap_t* jobjectwrap = iotjs_jobjectwrap_from_jobject(jble);
+iotjs_blehcisocket_t* iotjs_blehcisocket_instance_from_jval(iotjs_jval_t jble) {
+  iotjs_jobjectwrap_t* jobjectwrap = iotjs_jobjectwrap_from_jobject(&jble);
   return (iotjs_blehcisocket_t*)jobjectwrap;
 }
 
@@ -94,9 +93,9 @@ JHANDLER_FUNCTION(BindRaw) {
   int devId = 0;
   int* pDevId = NULL;
 
-  const iotjs_jval_t* raw = iotjs_jhandler_get_arg(jhandler, 0);
-  if (iotjs_jval_is_number(raw)) {
-    devId = iotjs_jval_as_number(raw);
+  iotjs_jval_t raw = *iotjs_jhandler_get_arg(jhandler, 0);
+  if (iotjs_jval_is_number(&raw)) {
+    devId = iotjs_jval_as_number(&raw);
     pDevId = &devId;
   }
 
@@ -182,11 +181,11 @@ JHANDLER_FUNCTION(BleHciSocketCons) {
   DJHANDLER_CHECK_ARGS(0);
 
   // Create object
-  const iotjs_jval_t* jblehcisocket = JHANDLER_GET_THIS(object);
+  iotjs_jval_t jblehcisocket = *JHANDLER_GET_THIS(object);
   iotjs_blehcisocket_t* blehcisocket = iotjs_blehcisocket_create(jblehcisocket);
   IOTJS_ASSERT(blehcisocket ==
                (iotjs_blehcisocket_t*)(iotjs_jval_get_object_native_handle(
-                   jblehcisocket)));
+                   &jblehcisocket)));
 }
 
 

--- a/src/modules/iotjs_module_blehcisocket.h
+++ b/src/modules/iotjs_module_blehcisocket.h
@@ -58,9 +58,8 @@ typedef struct {
 #define THIS iotjs_blehcisocket_t* iotjs_blehcisocket
 
 
-iotjs_blehcisocket_t* iotjs_blehcisocket_create(const iotjs_jval_t* jble);
-iotjs_blehcisocket_t* iotjs_blehcisocket_instance_from_jval(
-    const iotjs_jval_t* jble);
+iotjs_blehcisocket_t* iotjs_blehcisocket_create(iotjs_jval_t jble);
+iotjs_blehcisocket_t* iotjs_blehcisocket_instance_from_jval(iotjs_jval_t jble);
 
 
 void iotjs_blehcisocket_initialize(THIS);

--- a/src/modules/iotjs_module_fs.c
+++ b/src/modules/iotjs_module_fs.c
@@ -49,8 +49,8 @@ static void AfterAsync(uv_fs_t* req) {
   IOTJS_ASSERT(req_wrap != NULL);
   IOTJS_ASSERT(&req_wrap->req == req);
 
-  const iotjs_jval_t* cb = iotjs_reqwrap_jcallback(&req_wrap->reqwrap);
-  IOTJS_ASSERT(iotjs_jval_is_function(cb));
+  const iotjs_jval_t cb = *iotjs_reqwrap_jcallback(&req_wrap->reqwrap);
+  IOTJS_ASSERT(iotjs_jval_is_function(&cb));
 
   iotjs_jargs_t jarg = iotjs_jargs_create(2);
   if (req->result < 0) {
@@ -99,7 +99,7 @@ static void AfterAsync(uv_fs_t* req) {
     }
   }
 
-  iotjs_make_callback(cb, iotjs_jval_get_undefined(), &jarg);
+  iotjs_make_callback(&cb, iotjs_jval_get_undefined(), &jarg);
 
   iotjs_jargs_destroy(&jarg);
   iotjs_fs_reqwrap_destroy(req_wrap);
@@ -308,10 +308,10 @@ JHANDLER_FUNCTION(Write) {
 
 
 iotjs_jval_t MakeStatObject(uv_stat_t* statbuf) {
-  const iotjs_jval_t* fs = iotjs_module_get(MODULE_FS);
+  const iotjs_jval_t fs = *iotjs_module_get(MODULE_FS);
 
   iotjs_jval_t stat_prototype =
-      iotjs_jval_get_property(fs, IOTJS_MAGIC_STRING_STATS);
+      iotjs_jval_get_property(&fs, IOTJS_MAGIC_STRING_STATS);
   IOTJS_ASSERT(iotjs_jval_is_object(&stat_prototype));
 
   iotjs_jval_t jstat = iotjs_jval_create_object();
@@ -482,8 +482,8 @@ JHANDLER_FUNCTION(ReadDir) {
 
 static void StatsIsTypeOf(iotjs_jhandler_t* jhandler, int type) {
   DJHANDLER_CHECK_THIS(object);
-  const iotjs_jval_t* stats = JHANDLER_GET_THIS(object);
-  iotjs_jval_t mode = iotjs_jval_get_property(stats, IOTJS_MAGIC_STRING_MODE);
+  const iotjs_jval_t stats = *JHANDLER_GET_THIS(object);
+  iotjs_jval_t mode = iotjs_jval_get_property(&stats, IOTJS_MAGIC_STRING_MODE);
 
   int mode_number = (int)iotjs_jval_as_number(&mode);
 

--- a/src/modules/iotjs_module_https.h
+++ b/src/modules/iotjs_module_https.h
@@ -89,7 +89,7 @@ iotjs_https_t* iotjs_https_create(const char* URL, const char* method,
                                   const char* ca, const char* cert,
                                   const char* key,
                                   const bool reject_unauthorized,
-                                  const iotjs_jval_t* jthis);
+                                  iotjs_jval_t jthis);
 
 #define THIS iotjs_https_t* https_data
 // Some utility functions
@@ -97,7 +97,7 @@ void iotjs_https_check_done(THIS);
 void iotjs_https_cleanup(THIS);
 CURLM* iotjs_https_get_multi_handle(THIS);
 void iotjs_https_initialize_curl_opts(THIS);
-iotjs_jval_t* iotjs_https_jthis_from_https(THIS);
+iotjs_jval_t iotjs_https_jthis_from_https(THIS);
 bool iotjs_https_jcallback(THIS, const char* property,
                            const iotjs_jargs_t* jarg, bool resultvalue);
 void iotjs_https_call_read_onwrite(uv_timer_t* timer);
@@ -106,8 +106,7 @@ void iotjs_https_call_read_onwrite_async(THIS);
 // Functions almost directly called by JS via JHANDLER
 void iotjs_https_add_header(THIS, const char* char_header);
 void iotjs_https_data_to_write(THIS, iotjs_string_t read_chunk,
-                               const iotjs_jval_t* callback,
-                               const iotjs_jval_t* onwrite);
+                               iotjs_jval_t callback, iotjs_jval_t onwrite);
 void iotjs_https_finish_request(THIS);
 void iotjs_https_send_request(THIS);
 void iotjs_https_set_timeout(long ms, THIS);

--- a/src/modules/iotjs_module_i2c.h
+++ b/src/modules/iotjs_module_i2c.h
@@ -64,12 +64,12 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_i2c_reqwrap_t);
 
 
-iotjs_i2c_t* iotjs_i2c_instance_from_jval(const iotjs_jval_t* ji2c);
+iotjs_i2c_t* iotjs_i2c_instance_from_jval(const iotjs_jval_t ji2c);
 iotjs_i2c_reqwrap_t* iotjs_i2c_reqwrap_from_request(uv_work_t* req);
 #define THIS iotjs_i2c_reqwrap_t* i2c_reqwrap
 void iotjs_i2c_reqwrap_dispatched(THIS);
 uv_work_t* iotjs_i2c_reqwrap_req(THIS);
-const iotjs_jval_t* iotjs_i2c_reqwrap_jcallback(THIS);
+iotjs_jval_t iotjs_i2c_reqwrap_jcallback(THIS);
 iotjs_i2c_reqdata_t* iotjs_i2c_reqwrap_data(THIS);
 iotjs_i2c_t* iotjs_i2c_instance_from_reqwrap(THIS);
 #undef THIS

--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -25,10 +25,10 @@ JHANDLER_FUNCTION(Binding) {
 
   ModuleKind module_kind = (ModuleKind)JHANDLER_GET_ARG(0, number);
 
-  const iotjs_jval_t* jmodule =
-      iotjs_module_initialize_if_necessary(module_kind);
+  const iotjs_jval_t jmodule =
+      *iotjs_module_initialize_if_necessary(module_kind);
 
-  iotjs_jhandler_return_jval(jhandler, jmodule);
+  iotjs_jhandler_return_jval(jhandler, &jmodule);
 }
 
 
@@ -181,15 +181,15 @@ JHANDLER_FUNCTION(DoExit) {
 }
 
 
-void SetNativeSources(iotjs_jval_t* native_sources) {
+void SetNativeSources(iotjs_jval_t native_sources) {
   for (int i = 0; natives[i].name; i++) {
-    iotjs_jval_set_property_jval(native_sources, natives[i].name,
+    iotjs_jval_set_property_jval(&native_sources, natives[i].name,
                                  iotjs_jval_get_boolean(true));
   }
 }
 
 
-static void SetProcessEnv(iotjs_jval_t* process) {
+static void SetProcessEnv(iotjs_jval_t process) {
   const char *homedir, *iotjspath, *iotjsenv;
 
   homedir = getenv("HOME");
@@ -219,16 +219,16 @@ static void SetProcessEnv(iotjs_jval_t* process) {
   iotjs_jval_set_property_string_raw(&env, IOTJS_MAGIC_STRING_IOTJS_ENV,
                                      iotjsenv);
 
-  iotjs_jval_set_property_jval(process, IOTJS_MAGIC_STRING_ENV, &env);
+  iotjs_jval_set_property_jval(&process, IOTJS_MAGIC_STRING_ENV, &env);
 
   iotjs_jval_destroy(&env);
 }
 
 
-static void SetProcessIotjs(iotjs_jval_t* process) {
+static void SetProcessIotjs(iotjs_jval_t process) {
   // IoT.js specific
   iotjs_jval_t iotjs = iotjs_jval_create_object();
-  iotjs_jval_set_property_jval(process, IOTJS_MAGIC_STRING_IOTJS, &iotjs);
+  iotjs_jval_set_property_jval(&process, IOTJS_MAGIC_STRING_IOTJS, &iotjs);
 
   iotjs_jval_set_property_string_raw(&iotjs, IOTJS_MAGIC_STRING_BOARD,
                                      TOSTRING(TARGET_BOARD));
@@ -236,7 +236,7 @@ static void SetProcessIotjs(iotjs_jval_t* process) {
 }
 
 
-static void SetProcessArgv(iotjs_jval_t* process) {
+static void SetProcessArgv(iotjs_jval_t process) {
   const iotjs_environment_t* env = iotjs_environment_get();
   uint32_t argc = iotjs_environment_argc(env);
 
@@ -248,7 +248,7 @@ static void SetProcessArgv(iotjs_jval_t* process) {
     iotjs_jval_set_property_by_index(&argv, i, &arg);
     iotjs_jval_destroy(&arg);
   }
-  iotjs_jval_set_property_jval(process, IOTJS_MAGIC_STRING_ARGV, &argv);
+  iotjs_jval_set_property_jval(&process, IOTJS_MAGIC_STRING_ARGV, &argv);
 
   iotjs_jval_destroy(&argv);
 }
@@ -265,11 +265,11 @@ iotjs_jval_t InitProcess() {
   iotjs_jval_set_method(&process, IOTJS_MAGIC_STRING_CWD, Cwd);
   iotjs_jval_set_method(&process, IOTJS_MAGIC_STRING_CHDIR, Chdir);
   iotjs_jval_set_method(&process, IOTJS_MAGIC_STRING_DOEXIT, DoExit);
-  SetProcessEnv(&process);
+  SetProcessEnv(process);
 
   // process.native_sources
   iotjs_jval_t native_sources = iotjs_jval_create_object();
-  SetNativeSources(&native_sources);
+  SetNativeSources(native_sources);
   iotjs_jval_set_property_jval(&process, IOTJS_MAGIC_STRING_NATIVE_SOURCES,
                                &native_sources);
   iotjs_jval_destroy(&native_sources);
@@ -287,9 +287,9 @@ iotjs_jval_t InitProcess() {
                                      IOTJS_VERSION);
 
   // Set iotjs
-  SetProcessIotjs(&process);
+  SetProcessIotjs(process);
 
-  SetProcessArgv(&process);
+  SetProcessArgv(process);
 
   // Binding module id.
   iotjs_jval_t jbinding =

--- a/src/modules/iotjs_module_stm32f4dis.c
+++ b/src/modules/iotjs_module_stm32f4dis.c
@@ -22,7 +22,7 @@ iotjs_jval_t InitStm32f4dis() {
 
 #if defined(__NUTTX__)
 
-  iotjs_stm32f4dis_pin_initialize(&stm32f4dis);
+  iotjs_stm32f4dis_pin_initialize(stm32f4dis);
 
 #endif
 

--- a/src/modules/iotjs_module_stm32f4dis.h
+++ b/src/modules/iotjs_module_stm32f4dis.h
@@ -17,7 +17,7 @@
 #define IOTJS_MODULE_STM32F4DIS_H
 
 
-void iotjs_stm32f4dis_pin_initialize(const iotjs_jval_t* jobj);
+void iotjs_stm32f4dis_pin_initialize(iotjs_jval_t jobj);
 
 
 #endif /* IOTJS_MODULE_STM32F4DIS_H */

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -25,11 +25,11 @@
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(tcpwrap);
 
 
-iotjs_tcpwrap_t* iotjs_tcpwrap_create(const iotjs_jval_t* jtcp) {
+iotjs_tcpwrap_t* iotjs_tcpwrap_create(iotjs_jval_t jtcp) {
   iotjs_tcpwrap_t* tcpwrap = IOTJS_ALLOC(iotjs_tcpwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_tcpwrap_t, tcpwrap);
 
-  iotjs_handlewrap_initialize(&_this->handlewrap, jtcp,
+  iotjs_handlewrap_initialize(&_this->handlewrap, &jtcp,
                               (uv_handle_t*)(&_this->handle),
                               &this_module_native_info);
 
@@ -56,8 +56,8 @@ iotjs_tcpwrap_t* iotjs_tcpwrap_from_handle(uv_tcp_t* tcp_handle) {
 }
 
 
-iotjs_tcpwrap_t* iotjs_tcpwrap_from_jobject(const iotjs_jval_t* jtcp) {
-  iotjs_handlewrap_t* handlewrap = iotjs_handlewrap_from_jobject(jtcp);
+iotjs_tcpwrap_t* iotjs_tcpwrap_from_jobject(iotjs_jval_t jtcp) {
+  iotjs_handlewrap_t* handlewrap = iotjs_handlewrap_from_jobject(&jtcp);
   return (iotjs_tcpwrap_t*)handlewrap;
 }
 
@@ -69,9 +69,9 @@ uv_tcp_t* iotjs_tcpwrap_tcp_handle(iotjs_tcpwrap_t* tcpwrap) {
 }
 
 
-iotjs_jval_t* iotjs_tcpwrap_jobject(iotjs_tcpwrap_t* tcpwrap) {
+iotjs_jval_t iotjs_tcpwrap_jobject(iotjs_tcpwrap_t* tcpwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_tcpwrap_t, tcpwrap);
-  return iotjs_handlewrap_jobject(&_this->handlewrap);
+  return *iotjs_handlewrap_jobject(&_this->handlewrap);
 }
 
 
@@ -81,12 +81,11 @@ iotjs_jval_t* iotjs_tcpwrap_jobject(iotjs_tcpwrap_t* tcpwrap) {
 static void iotjs_connect_reqwrap_destroy(THIS);
 
 
-iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(
-    const iotjs_jval_t* jcallback) {
+iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(iotjs_jval_t jcallback) {
   iotjs_connect_reqwrap_t* connect_reqwrap =
       IOTJS_ALLOC(iotjs_connect_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_connect_reqwrap_t, connect_reqwrap);
-  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
+  iotjs_reqwrap_initialize(&_this->reqwrap, &jcallback, (uv_req_t*)&_this->req);
   return connect_reqwrap;
 }
 
@@ -111,9 +110,9 @@ uv_connect_t* iotjs_connect_reqwrap_req(THIS) {
 }
 
 
-const iotjs_jval_t* iotjs_connect_reqwrap_jcallback(THIS) {
+iotjs_jval_t iotjs_connect_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_connect_reqwrap_t, connect_reqwrap);
-  return iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 #undef THIS
@@ -135,11 +134,10 @@ iotjs_string_t iotjs_create_ip(const iotjs_string_t* address) {
 static void iotjs_write_reqwrap_destroy(THIS);
 
 
-iotjs_write_reqwrap_t* iotjs_write_reqwrap_create(
-    const iotjs_jval_t* jcallback) {
+iotjs_write_reqwrap_t* iotjs_write_reqwrap_create(iotjs_jval_t jcallback) {
   iotjs_write_reqwrap_t* write_reqwrap = IOTJS_ALLOC(iotjs_write_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_write_reqwrap_t, write_reqwrap);
-  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
+  iotjs_reqwrap_initialize(&_this->reqwrap, &jcallback, (uv_req_t*)&_this->req);
   return write_reqwrap;
 }
 
@@ -164,9 +162,9 @@ uv_write_t* iotjs_write_reqwrap_req(THIS) {
 }
 
 
-const iotjs_jval_t* iotjs_write_reqwrap_jcallback(THIS) {
+iotjs_jval_t iotjs_write_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_write_reqwrap_t, write_reqwrap);
-  return iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 #undef THIS
@@ -179,12 +177,12 @@ static void iotjs_shutdown_reqwrap_destroy(THIS);
 
 
 iotjs_shutdown_reqwrap_t* iotjs_shutdown_reqwrap_create(
-    const iotjs_jval_t* jcallback) {
+    iotjs_jval_t jcallback) {
   iotjs_shutdown_reqwrap_t* shutdown_reqwrap =
       IOTJS_ALLOC(iotjs_shutdown_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_shutdown_reqwrap_t,
                                      shutdown_reqwrap);
-  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
+  iotjs_reqwrap_initialize(&_this->reqwrap, &jcallback, (uv_req_t*)&_this->req);
   return shutdown_reqwrap;
 }
 
@@ -209,9 +207,9 @@ uv_shutdown_t* iotjs_shutdown_reqwrap_req(THIS) {
 }
 
 
-const iotjs_jval_t* iotjs_shutdown_reqwrap_jcallback(THIS) {
+iotjs_jval_t iotjs_shutdown_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_shutdown_reqwrap_t, shutdown_reqwrap);
-  return iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 #undef THIS
@@ -221,7 +219,7 @@ JHANDLER_FUNCTION(TCP) {
   DJHANDLER_CHECK_THIS(object);
   DJHANDLER_CHECK_ARGS(0);
 
-  const iotjs_jval_t* jtcp = JHANDLER_GET_THIS(object);
+  iotjs_jval_t jtcp = *JHANDLER_GET_THIS(object);
   iotjs_tcpwrap_create(jtcp);
 }
 
@@ -235,11 +233,11 @@ void AfterClose(uv_handle_t* handle) {
   iotjs_handlewrap_t* wrap = iotjs_handlewrap_from_handle(handle);
 
   // tcp object.
-  const iotjs_jval_t* jtcp = iotjs_handlewrap_jobject(wrap);
+  iotjs_jval_t jtcp = *iotjs_handlewrap_jobject(wrap);
 
   // callback function.
   iotjs_jval_t jcallback =
-      iotjs_jval_get_property(jtcp, IOTJS_MAGIC_STRING_ONCLOSE);
+      iotjs_jval_get_property(&jtcp, IOTJS_MAGIC_STRING_ONCLOSE);
   if (iotjs_jval_is_function(&jcallback)) {
     iotjs_make_callback(&jcallback, iotjs_jval_get_undefined(),
                         iotjs_jargs_get_empty());
@@ -291,15 +289,15 @@ static void AfterConnect(uv_connect_t* req, int status) {
 
   // Take callback function object.
   // function afterConnect(status)
-  const iotjs_jval_t* jcallback = iotjs_connect_reqwrap_jcallback(req_wrap);
-  IOTJS_ASSERT(iotjs_jval_is_function(jcallback));
+  iotjs_jval_t jcallback = iotjs_connect_reqwrap_jcallback(req_wrap);
+  IOTJS_ASSERT(iotjs_jval_is_function(&jcallback));
 
   // Only parameter is status code.
   iotjs_jargs_t args = iotjs_jargs_create(1);
   iotjs_jargs_append_number(&args, status);
 
   // Make callback.
-  iotjs_make_callback(jcallback, iotjs_jval_get_undefined(), &args);
+  iotjs_make_callback(&jcallback, iotjs_jval_get_undefined(), &args);
 
   // Destroy args
   iotjs_jargs_destroy(&args);
@@ -320,7 +318,7 @@ JHANDLER_FUNCTION(Connect) {
 
   iotjs_string_t address = JHANDLER_GET_ARG(0, string);
   int port = JHANDLER_GET_ARG(1, number);
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG(2, function);
+  iotjs_jval_t jcallback = *JHANDLER_GET_ARG(2, function);
 
   sockaddr_in addr;
   int err = uv_ip4_addr(iotjs_string_data(&address), port, &addr);
@@ -354,11 +352,11 @@ static void OnConnection(uv_stream_t* handle, int status) {
   iotjs_tcpwrap_t* tcp_wrap = iotjs_tcpwrap_from_handle((uv_tcp_t*)handle);
 
   // Tcp object
-  const iotjs_jval_t* jtcp = iotjs_tcpwrap_jobject(tcp_wrap);
+  iotjs_jval_t jtcp = iotjs_tcpwrap_jobject(tcp_wrap);
 
   // `onconnection` callback.
   iotjs_jval_t jonconnection =
-      iotjs_jval_get_property(jtcp, IOTJS_MAGIC_STRING_ONCONNECTION);
+      iotjs_jval_get_property(&jtcp, IOTJS_MAGIC_STRING_ONCONNECTION);
   IOTJS_ASSERT(iotjs_jval_is_function(&jonconnection));
 
   // The callback takes two parameter
@@ -370,7 +368,7 @@ static void OnConnection(uv_stream_t* handle, int status) {
   if (status == 0) {
     // Create client socket handle wrapper.
     iotjs_jval_t jcreate_tcp =
-        iotjs_jval_get_property(jtcp, IOTJS_MAGIC_STRING_CREATETCP);
+        iotjs_jval_get_property(&jtcp, IOTJS_MAGIC_STRING_CREATETCP);
     IOTJS_ASSERT(iotjs_jval_is_function(&jcreate_tcp));
 
     iotjs_jval_t jclient_tcp =
@@ -395,7 +393,7 @@ static void OnConnection(uv_stream_t* handle, int status) {
     iotjs_jval_destroy(&jclient_tcp);
   }
 
-  iotjs_make_callback(&jonconnection, jtcp, &args);
+  iotjs_make_callback(&jonconnection, &jtcp, &args);
 
   iotjs_jval_destroy(&jonconnection);
   iotjs_jargs_destroy(&args);
@@ -422,14 +420,14 @@ void AfterWrite(uv_write_t* req, int status) {
   IOTJS_ASSERT(tcp_wrap != NULL);
 
   // Take callback function object.
-  const iotjs_jval_t* jcallback = iotjs_write_reqwrap_jcallback(req_wrap);
+  iotjs_jval_t jcallback = iotjs_write_reqwrap_jcallback(req_wrap);
 
   // Only parameter is status code.
   iotjs_jargs_t args = iotjs_jargs_create(1);
   iotjs_jargs_append_number(&args, status);
 
   // Make callback.
-  iotjs_make_callback(jcallback, iotjs_jval_get_undefined(), &args);
+  iotjs_make_callback(&jcallback, iotjs_jval_get_undefined(), &args);
 
   // Destroy args
   iotjs_jargs_destroy(&args);
@@ -452,7 +450,7 @@ JHANDLER_FUNCTION(Write) {
   buf.base = buffer;
   buf.len = len;
 
-  const iotjs_jval_t* arg1 = JHANDLER_GET_ARG(1, object);
+  iotjs_jval_t arg1 = *JHANDLER_GET_ARG(1, object);
   iotjs_write_reqwrap_t* req_wrap = iotjs_write_reqwrap_create(arg1);
 
   int err = uv_write(iotjs_write_reqwrap_req(req_wrap),
@@ -481,16 +479,16 @@ void OnRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   iotjs_tcpwrap_t* tcp_wrap = iotjs_tcpwrap_from_handle((uv_tcp_t*)handle);
 
   // tcp handle
-  const iotjs_jval_t* jtcp = iotjs_tcpwrap_jobject(tcp_wrap);
+  iotjs_jval_t jtcp = iotjs_tcpwrap_jobject(tcp_wrap);
 
   // socket object
   iotjs_jval_t jsocket =
-      iotjs_jval_get_property(jtcp, IOTJS_MAGIC_STRING_OWNER);
+      iotjs_jval_get_property(&jtcp, IOTJS_MAGIC_STRING_OWNER);
   IOTJS_ASSERT(iotjs_jval_is_object(&jsocket));
 
   // onread callback
   iotjs_jval_t jonread =
-      iotjs_jval_get_property(jtcp, IOTJS_MAGIC_STRING_ONREAD);
+      iotjs_jval_get_property(&jtcp, IOTJS_MAGIC_STRING_ONREAD);
   IOTJS_ASSERT(iotjs_jval_is_function(&jonread));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(4);
@@ -545,13 +543,13 @@ static void AfterShutdown(uv_shutdown_t* req, int status) {
   IOTJS_ASSERT(tcp_wrap != NULL);
 
   // function onShutdown(status)
-  const iotjs_jval_t* jonshutdown = iotjs_shutdown_reqwrap_jcallback(req_wrap);
-  IOTJS_ASSERT(iotjs_jval_is_function(jonshutdown));
+  iotjs_jval_t jonshutdown = iotjs_shutdown_reqwrap_jcallback(req_wrap);
+  IOTJS_ASSERT(iotjs_jval_is_function(&jonshutdown));
 
   iotjs_jargs_t args = iotjs_jargs_create(1);
   iotjs_jargs_append_number(&args, status);
 
-  iotjs_make_callback(jonshutdown, iotjs_jval_get_undefined(), &args);
+  iotjs_make_callback(&jonshutdown, iotjs_jval_get_undefined(), &args);
 
   iotjs_jargs_destroy(&args);
 
@@ -564,7 +562,7 @@ JHANDLER_FUNCTION(Shutdown) {
 
   DJHANDLER_CHECK_ARGS(1, function);
 
-  const iotjs_jval_t* arg0 = JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t arg0 = *JHANDLER_GET_ARG(0, object);
   iotjs_shutdown_reqwrap_t* req_wrap = iotjs_shutdown_reqwrap_create(arg0);
 
   int err = uv_shutdown(iotjs_shutdown_reqwrap_req(req_wrap),
@@ -604,7 +602,7 @@ JHANDLER_FUNCTION(ErrName) {
 }
 
 // used in iotjs_module_udp.cpp
-void AddressToJS(const iotjs_jval_t* obj, const sockaddr* addr) {
+void AddressToJS(iotjs_jval_t obj, const sockaddr* addr) {
   char ip[INET6_ADDRSTRLEN];
   const sockaddr_in* a4;
   const sockaddr_in6* a6;
@@ -615,10 +613,10 @@ void AddressToJS(const iotjs_jval_t* obj, const sockaddr* addr) {
       a6 = (const sockaddr_in6*)(addr);
       uv_inet_ntop(AF_INET6, &a6->sin6_addr, ip, sizeof ip);
       port = ntohs(a6->sin6_port);
-      iotjs_jval_set_property_string_raw(obj, IOTJS_MAGIC_STRING_ADDRESS, ip);
-      iotjs_jval_set_property_string_raw(obj, IOTJS_MAGIC_STRING_FAMILY,
+      iotjs_jval_set_property_string_raw(&obj, IOTJS_MAGIC_STRING_ADDRESS, ip);
+      iotjs_jval_set_property_string_raw(&obj, IOTJS_MAGIC_STRING_FAMILY,
                                          IOTJS_MAGIC_STRING_IPV6);
-      iotjs_jval_set_property_number(obj, IOTJS_MAGIC_STRING_PORT, port);
+      iotjs_jval_set_property_number(&obj, IOTJS_MAGIC_STRING_PORT, port);
       break;
     }
 
@@ -626,15 +624,15 @@ void AddressToJS(const iotjs_jval_t* obj, const sockaddr* addr) {
       a4 = (const sockaddr_in*)(addr);
       uv_inet_ntop(AF_INET, &a4->sin_addr, ip, sizeof ip);
       port = ntohs(a4->sin_port);
-      iotjs_jval_set_property_string_raw(obj, IOTJS_MAGIC_STRING_ADDRESS, ip);
-      iotjs_jval_set_property_string_raw(obj, IOTJS_MAGIC_STRING_FAMILY,
+      iotjs_jval_set_property_string_raw(&obj, IOTJS_MAGIC_STRING_ADDRESS, ip);
+      iotjs_jval_set_property_string_raw(&obj, IOTJS_MAGIC_STRING_FAMILY,
                                          IOTJS_MAGIC_STRING_IPV4);
-      iotjs_jval_set_property_number(obj, IOTJS_MAGIC_STRING_PORT, port);
+      iotjs_jval_set_property_number(&obj, IOTJS_MAGIC_STRING_PORT, port);
       break;
     }
 
     default: {
-      iotjs_jval_set_property_string_raw(obj, IOTJS_MAGIC_STRING_ADDRESS, "");
+      iotjs_jval_set_property_string_raw(&obj, IOTJS_MAGIC_STRING_ADDRESS, "");
       break;
     }
   }

--- a/src/modules/iotjs_module_tcp.h
+++ b/src/modules/iotjs_module_tcp.h
@@ -35,13 +35,13 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_tcpwrap_t);
 
 
-iotjs_tcpwrap_t* iotjs_tcpwrap_create(const iotjs_jval_t* jtcp);
+iotjs_tcpwrap_t* iotjs_tcpwrap_create(iotjs_jval_t jtcp);
 
 iotjs_tcpwrap_t* iotjs_tcpwrap_from_handle(uv_tcp_t* handle);
-iotjs_tcpwrap_t* iotjs_tcpwrap_from_jobject(const iotjs_jval_t* jtcp);
+iotjs_tcpwrap_t* iotjs_tcpwrap_from_jobject(iotjs_jval_t jtcp);
 
 uv_tcp_t* iotjs_tcpwrap_tcp_handle(iotjs_tcpwrap_t* tcpwrap);
-iotjs_jval_t* iotjs_tcpwrap_jobject(iotjs_tcpwrap_t* tcpwrap);
+iotjs_jval_t iotjs_tcpwrap_jobject(iotjs_tcpwrap_t* tcpwrap);
 
 
 typedef struct {
@@ -50,11 +50,10 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_connect_reqwrap_t);
 
 #define THIS iotjs_connect_reqwrap_t* connect_reqwrap
-iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(
-    const iotjs_jval_t* jcallback);
+iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(iotjs_jval_t jcallback);
 void iotjs_connect_reqwrap_dispatched(THIS);
 uv_connect_t* iotjs_connect_reqwrap_req(THIS);
-const iotjs_jval_t* iotjs_connect_reqwrap_jcallback(THIS);
+iotjs_jval_t iotjs_connect_reqwrap_jcallback(THIS);
 #undef THIS
 
 
@@ -64,11 +63,10 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_write_reqwrap_t);
 
 #define THIS iotjs_write_reqwrap_t* write_reqwrap
-iotjs_write_reqwrap_t* iotjs_write_reqwrap_create(
-    const iotjs_jval_t* jcallback);
+iotjs_write_reqwrap_t* iotjs_write_reqwrap_create(iotjs_jval_t jcallback);
 void iotjs_write_reqwrap_dispatched(THIS);
 uv_write_t* iotjs_write_reqwrap_req(THIS);
-const iotjs_jval_t* iotjs_write_reqwrap_jcallback(THIS);
+iotjs_jval_t iotjs_write_reqwrap_jcallback(THIS);
 #undef THIS
 
 
@@ -78,15 +76,14 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_shutdown_reqwrap_t);
 
 #define THIS iotjs_shutdown_reqwrap_t* shutdown_reqwrap
-iotjs_shutdown_reqwrap_t* iotjs_shutdown_reqwrap_create(
-    const iotjs_jval_t* jcallback);
+iotjs_shutdown_reqwrap_t* iotjs_shutdown_reqwrap_create(iotjs_jval_t jcallback);
 void iotjs_shutdown_reqwrap_dispatched(THIS);
 uv_shutdown_t* iotjs_shutdown_reqwrap_req(THIS);
-const iotjs_jval_t* iotjs_shutdown_reqwrap_jcallback(THIS);
+iotjs_jval_t iotjs_shutdown_reqwrap_jcallback(THIS);
 #undef THIS
 
 
-void AddressToJS(const iotjs_jval_t* obj, const sockaddr* addr);
+void AddressToJS(iotjs_jval_t obj, const sockaddr* addr);
 
 iotjs_string_t iotjs_create_ip(const iotjs_string_t* address);
 
@@ -95,7 +92,7 @@ iotjs_string_t iotjs_create_ip(const iotjs_string_t* address);
     DJHANDLER_CHECK_ARGS(1, object);                                           \
                                                                                \
     iotjs_##wraptype##_t* wrap =                                               \
-        iotjs_##wraptype##_from_jobject(JHANDLER_GET_THIS(object));            \
+        iotjs_##wraptype##_from_jobject(*JHANDLER_GET_THIS(object));           \
     IOTJS_ASSERT(wrap != NULL);                                                \
                                                                                \
     sockaddr_storage storage;                                                  \
@@ -103,7 +100,7 @@ iotjs_string_t iotjs_create_ip(const iotjs_string_t* address);
     sockaddr* const addr = (sockaddr*)(&storage);                              \
     int err = function(iotjs_##wraptype##_##handletype(wrap), addr, &addrlen); \
     if (err == 0)                                                              \
-      AddressToJS(JHANDLER_GET_ARG(0, object), addr);                          \
+      AddressToJS(*JHANDLER_GET_ARG(0, object), addr);                         \
     iotjs_jhandler_return_number(jhandler, err);                               \
   }
 

--- a/src/modules/iotjs_module_testdriver.c
+++ b/src/modules/iotjs_module_testdriver.c
@@ -23,19 +23,19 @@ JHANDLER_FUNCTION(IsAliveExceptFor) {
   const iotjs_environment_t* env = iotjs_environment_get();
   uv_loop_t* loop = iotjs_environment_loop(env);
 
-  const iotjs_jval_t* arg0 = iotjs_jhandler_get_arg(jhandler, 0);
+  const iotjs_jval_t arg0 = *iotjs_jhandler_get_arg(jhandler, 0);
 
-  if (iotjs_jval_is_null(arg0)) {
+  if (iotjs_jval_is_null(&arg0)) {
     int alive = uv_loop_alive(loop);
 
     iotjs_jhandler_return_boolean(jhandler, alive);
   } else {
-    JHANDLER_CHECK(iotjs_jval_is_object(arg0));
+    JHANDLER_CHECK(iotjs_jval_is_object(&arg0));
 
     iotjs_jval_t jtimer =
-        iotjs_jval_get_property(arg0, IOTJS_MAGIC_STRING_HANDLER);
+        iotjs_jval_get_property(&arg0, IOTJS_MAGIC_STRING_HANDLER);
 
-    iotjs_timerwrap_t* timer_wrap = iotjs_timerwrap_from_jobject(&jtimer);
+    iotjs_timerwrap_t* timer_wrap = iotjs_timerwrap_from_jobject(jtimer);
     iotjs_jval_destroy(&jtimer);
 
     bool has_active_reqs = uv_loop_has_active_reqs(loop);

--- a/src/modules/iotjs_module_timer.c
+++ b/src/modules/iotjs_module_timer.c
@@ -22,12 +22,12 @@ static void iotjs_timerwrap_on_timeout(iotjs_timerwrap_t* timerwrap);
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(timerwrap);
 
 
-iotjs_timerwrap_t* iotjs_timerwrap_create(const iotjs_jval_t* jtimer) {
+iotjs_timerwrap_t* iotjs_timerwrap_create(const iotjs_jval_t jtimer) {
   iotjs_timerwrap_t* timerwrap = IOTJS_ALLOC(iotjs_timerwrap_t);
   uv_timer_t* uv_timer = IOTJS_ALLOC(uv_timer_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_timerwrap_t, timerwrap);
 
-  iotjs_handlewrap_initialize(&_this->handlewrap, jtimer,
+  iotjs_handlewrap_initialize(&_this->handlewrap, &jtimer,
                               (uv_handle_t*)(uv_timer),
                               &this_module_native_info);
 
@@ -86,10 +86,10 @@ static void iotjs_timerwrap_on_timeout(iotjs_timerwrap_t* timerwrap) {
   IOTJS_VALIDATABLE_STRUCT_METHOD_VALIDATE(iotjs_timerwrap_t, timerwrap);
 
   // Call javascript timeout handler function.
-  const iotjs_jval_t* jobject = iotjs_timerwrap_jobject(timerwrap);
+  iotjs_jval_t jobject = iotjs_timerwrap_jobject(timerwrap);
   iotjs_jval_t jcallback =
-      iotjs_jval_get_property(jobject, IOTJS_MAGIC_STRING_HANDLETIMEOUT);
-  iotjs_make_callback(&jcallback, jobject, iotjs_jargs_get_empty());
+      iotjs_jval_get_property(&jobject, IOTJS_MAGIC_STRING_HANDLETIMEOUT);
+  iotjs_make_callback(&jcallback, &jobject, iotjs_jargs_get_empty());
   iotjs_jval_destroy(&jcallback);
 }
 
@@ -100,10 +100,10 @@ uv_timer_t* iotjs_timerwrap_handle(iotjs_timerwrap_t* timerwrap) {
 }
 
 
-iotjs_jval_t* iotjs_timerwrap_jobject(iotjs_timerwrap_t* timerwrap) {
+iotjs_jval_t iotjs_timerwrap_jobject(iotjs_timerwrap_t* timerwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_timerwrap_t, timerwrap);
-  iotjs_jval_t* jobject = iotjs_handlewrap_jobject(&_this->handlewrap);
-  IOTJS_ASSERT(iotjs_jval_is_object(jobject));
+  iotjs_jval_t jobject = *iotjs_handlewrap_jobject(&_this->handlewrap);
+  IOTJS_ASSERT(iotjs_jval_is_object(&jobject));
   return jobject;
 }
 
@@ -117,8 +117,8 @@ iotjs_timerwrap_t* iotjs_timerwrap_from_handle(uv_timer_t* timer_handle) {
 }
 
 
-iotjs_timerwrap_t* iotjs_timerwrap_from_jobject(const iotjs_jval_t* jtimer) {
-  iotjs_handlewrap_t* handlewrap = iotjs_handlewrap_from_jobject(jtimer);
+iotjs_timerwrap_t* iotjs_timerwrap_from_jobject(const iotjs_jval_t jtimer) {
+  iotjs_handlewrap_t* handlewrap = iotjs_handlewrap_from_jobject(&jtimer);
   return (iotjs_timerwrap_t*)handlewrap;
 }
 
@@ -151,11 +151,13 @@ JHANDLER_FUNCTION(Stop) {
 JHANDLER_FUNCTION(Timer) {
   JHANDLER_CHECK_THIS(object);
 
-  const iotjs_jval_t* jtimer = JHANDLER_GET_THIS(object);
+  const iotjs_jval_t jtimer = *JHANDLER_GET_THIS(object);
 
   iotjs_timerwrap_t* timer_wrap = iotjs_timerwrap_create(jtimer);
-  IOTJS_ASSERT(iotjs_jval_is_object(iotjs_timerwrap_jobject(timer_wrap)));
-  IOTJS_ASSERT(iotjs_jval_get_object_native_handle(jtimer) != 0);
+
+  iotjs_jval_t jobject = iotjs_timerwrap_jobject(timer_wrap);
+  IOTJS_ASSERT(iotjs_jval_is_object(&jobject));
+  IOTJS_ASSERT(iotjs_jval_get_object_native_handle(&jtimer) != 0);
 }
 
 

--- a/src/modules/iotjs_module_timer.h
+++ b/src/modules/iotjs_module_timer.h
@@ -26,13 +26,13 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_timerwrap_t);
 
 
-iotjs_timerwrap_t* iotjs_timerwrap_create(const iotjs_jval_t* jtimer);
+iotjs_timerwrap_t* iotjs_timerwrap_create(const iotjs_jval_t jtimer);
 
-iotjs_timerwrap_t* iotjs_timerwrap_from_jobject(const iotjs_jval_t* jtimer);
+iotjs_timerwrap_t* iotjs_timerwrap_from_jobject(const iotjs_jval_t jtimer);
 iotjs_timerwrap_t* iotjs_timerwrap_from_handle(uv_timer_t* timer_handle);
 
 uv_timer_t* iotjs_timerwrap_handle(iotjs_timerwrap_t* timerwrap);
-iotjs_jval_t* iotjs_timerwrap_jobject(iotjs_timerwrap_t* timerwrap);
+iotjs_jval_t iotjs_timerwrap_jobject(iotjs_timerwrap_t* timerwrap);
 
 // Start timer.
 int iotjs_timerwrap_start(iotjs_timerwrap_t* timerwrap, uint64_t timeout,

--- a/src/modules/iotjs_module_uart.c
+++ b/src/modules/iotjs_module_uart.c
@@ -20,14 +20,13 @@
 #include "iotjs_objectwrap.h"
 
 
-static iotjs_uart_t* iotjs_uart_instance_from_jval(const iotjs_jval_t* juart);
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(uart);
 
-static iotjs_uart_t* iotjs_uart_create(const iotjs_jval_t* juart) {
+static iotjs_uart_t* iotjs_uart_create(iotjs_jval_t juart) {
   iotjs_uart_t* uart = IOTJS_ALLOC(iotjs_uart_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_uart_t, uart);
 
-  iotjs_handlewrap_initialize(&_this->handlewrap, juart,
+  iotjs_handlewrap_initialize(&_this->handlewrap, &juart,
                               (uv_handle_t*)(&_this->poll_handle),
                               &this_module_native_info);
 
@@ -46,12 +45,13 @@ static void iotjs_uart_destroy(iotjs_uart_t* uart) {
 #define THIS iotjs_uart_reqwrap_t* uart_reqwrap
 
 
-static iotjs_uart_reqwrap_t* iotjs_uart_reqwrap_create(
-    const iotjs_jval_t* jcallback, iotjs_uart_t* uart, UartOp op) {
+static iotjs_uart_reqwrap_t* iotjs_uart_reqwrap_create(iotjs_jval_t jcallback,
+                                                       iotjs_uart_t* uart,
+                                                       UartOp op) {
   iotjs_uart_reqwrap_t* uart_reqwrap = IOTJS_ALLOC(iotjs_uart_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_uart_reqwrap_t, uart_reqwrap);
 
-  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
+  iotjs_reqwrap_initialize(&_this->reqwrap, &jcallback, (uv_req_t*)&_this->req);
 
   _this->req_data.op = op;
   _this->uart_instance = uart;
@@ -79,14 +79,14 @@ static uv_work_t* iotjs_uart_reqwrap_req(THIS) {
 }
 
 
-static const iotjs_jval_t* iotjs_uart_reqwrap_jcallback(THIS) {
+static iotjs_jval_t iotjs_uart_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_uart_reqwrap_t, uart_reqwrap);
-  return iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 
-static iotjs_uart_t* iotjs_uart_instance_from_jval(const iotjs_jval_t* juart) {
-  iotjs_handlewrap_t* handlewrap = iotjs_handlewrap_from_jobject(juart);
+static iotjs_uart_t* iotjs_uart_instance_from_jval(iotjs_jval_t juart) {
+  iotjs_handlewrap_t* handlewrap = iotjs_handlewrap_from_jobject(&juart);
   return (iotjs_uart_t*)handlewrap;
 }
 
@@ -202,16 +202,16 @@ static void iotjs_uart_after_worker(uv_work_t* work_req, int status) {
     }
   }
 
-  const iotjs_jval_t* jcallback = iotjs_uart_reqwrap_jcallback(req_wrap);
-  iotjs_make_callback(jcallback, iotjs_jval_get_undefined(), &jargs);
+  iotjs_jval_t jcallback = iotjs_uart_reqwrap_jcallback(req_wrap);
+  iotjs_make_callback(&jcallback, iotjs_jval_get_undefined(), &jargs);
 
   iotjs_jargs_destroy(&jargs);
   iotjs_uart_reqwrap_dispatched(req_wrap);
 }
 
 
-static void iotjs_uart_onread(iotjs_jval_t* jthis, char* buf) {
-  iotjs_jval_t jemit = iotjs_jval_get_property(jthis, "emit");
+static void iotjs_uart_onread(iotjs_jval_t jthis, char* buf) {
+  iotjs_jval_t jemit = iotjs_jval_get_property(&jthis, "emit");
   IOTJS_ASSERT(iotjs_jval_is_function(&jemit));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(2);
@@ -219,7 +219,7 @@ static void iotjs_uart_onread(iotjs_jval_t* jthis, char* buf) {
   iotjs_jval_t data = iotjs_jval_create_string_raw(buf);
   iotjs_jargs_append_jval(&jargs, &str);
   iotjs_jargs_append_jval(&jargs, &data);
-  iotjs_jhelper_call_ok(&jemit, jthis, &jargs);
+  iotjs_jhelper_call_ok(&jemit, &jthis, &jargs);
 
   iotjs_jval_destroy(&str);
   iotjs_jval_destroy(&data);
@@ -237,7 +237,7 @@ void iotjs_uart_read_cb(uv_poll_t* req, int status, int events) {
   if (i > 0) {
     buf[i] = '\0';
     DDDLOG("%s - read data: %s", __func__, buf);
-    iotjs_uart_onread(&_this->jemitter_this, buf);
+    iotjs_uart_onread(_this->jemitter_this, buf);
   }
 }
 
@@ -258,23 +258,23 @@ JHANDLER_FUNCTION(UartConstructor) {
   DJHANDLER_CHECK_ARGS(3, object, object, function);
 
   // Create UART object
-  const iotjs_jval_t* juart = JHANDLER_GET_THIS(object);
+  iotjs_jval_t juart = *JHANDLER_GET_THIS(object);
   iotjs_uart_t* uart = iotjs_uart_create(juart);
   IOTJS_ASSERT(uart == iotjs_uart_instance_from_jval(juart));
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_uart_t, uart);
 
-  const iotjs_jval_t* jconfiguration = JHANDLER_GET_ARG(0, object);
-  const iotjs_jval_t* jemitter_this = JHANDLER_GET_ARG(1, object);
-  _this->jemitter_this = iotjs_jval_create_copied(jemitter_this);
-  const iotjs_jval_t* jcallback = JHANDLER_GET_ARG(2, function);
+  iotjs_jval_t jconfiguration = *JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t jemitter_this = *JHANDLER_GET_ARG(1, object);
+  _this->jemitter_this = iotjs_jval_create_copied(&jemitter_this);
+  iotjs_jval_t jcallback = *JHANDLER_GET_ARG(2, function);
 
   // set configuration
   iotjs_jval_t jdevice =
-      iotjs_jval_get_property(jconfiguration, IOTJS_MAGIC_STRING_DEVICE);
+      iotjs_jval_get_property(&jconfiguration, IOTJS_MAGIC_STRING_DEVICE);
   iotjs_jval_t jbaud_rate =
-      iotjs_jval_get_property(jconfiguration, IOTJS_MAGIC_STRING_BAUDRATE);
+      iotjs_jval_get_property(&jconfiguration, IOTJS_MAGIC_STRING_BAUDRATE);
   iotjs_jval_t jdata_bits =
-      iotjs_jval_get_property(jconfiguration, IOTJS_MAGIC_STRING_DATABITS);
+      iotjs_jval_get_property(&jconfiguration, IOTJS_MAGIC_STRING_DATABITS);
 
   _this->device_path = iotjs_jval_as_string(&jdevice);
   _this->baud_rate = iotjs_jval_as_number(&jbaud_rate);
@@ -305,7 +305,7 @@ JHANDLER_FUNCTION(Write) {
   _this->buf_len = iotjs_string_size(&_this->buf_data);
 
   if (!jerry_value_is_null(jcallback)) {
-    UART_ASYNC(write, uart, &jcallback, kUartOpWrite);
+    UART_ASYNC(write, uart, jcallback, kUartOpWrite);
   } else {
     bool result = iotjs_uart_write(uart);
     iotjs_string_destroy(&_this->buf_data);
@@ -330,7 +330,7 @@ JHANDLER_FUNCTION(Close) {
   iotjs_jval_destroy(&_this->jemitter_this);
 
   if (!jerry_value_is_null(jcallback)) {
-    UART_ASYNC(close, uart, &jcallback, kUartOpClose);
+    UART_ASYNC(close, uart, jcallback, kUartOpClose);
   } else {
     if (!iotjs_uart_close(uart)) {
       JHANDLER_THROW(COMMON, "UART Close Error");

--- a/src/modules/iotjs_module_udp.h
+++ b/src/modules/iotjs_module_udp.h
@@ -29,13 +29,13 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_udpwrap_t);
 
 
-iotjs_udpwrap_t* iotjs_udpwrap_create(const iotjs_jval_t* judp);
+iotjs_udpwrap_t* iotjs_udpwrap_create(iotjs_jval_t judp);
 
 iotjs_udpwrap_t* iotjs_udpwrap_from_handle(uv_udp_t* handle);
-iotjs_udpwrap_t* iotjs_udpwrap_from_jobject(const iotjs_jval_t* judp);
+iotjs_udpwrap_t* iotjs_udpwrap_from_jobject(iotjs_jval_t judp);
 
 uv_udp_t* iotjs_udpwrap_udp_handle(iotjs_udpwrap_t* udpwrap);
-iotjs_jval_t* iotjs_udpwrap_jobject(iotjs_udpwrap_t* udpwrap);
+iotjs_jval_t iotjs_udpwrap_jobject(iotjs_udpwrap_t* udpwrap);
 
 
 typedef struct {
@@ -47,14 +47,14 @@ typedef struct {
 
 #define THIS iotjs_send_reqwrap_t* send_reqwrap
 
-iotjs_send_reqwrap_t* iotjs_send_reqwrap_create(const iotjs_jval_t* jcallback,
+iotjs_send_reqwrap_t* iotjs_send_reqwrap_create(iotjs_jval_t jcallback,
                                                 void* req_data,
                                                 const size_t msg_size);
 
 void iotjs_send_reqwrap_dispatched(THIS);
 
 uv_udp_send_t* iotjs_send_reqwrap_req(THIS);
-const iotjs_jval_t* iotjs_send_reqwrap_jcallback(THIS);
+iotjs_jval_t iotjs_send_reqwrap_jcallback(THIS);
 
 #undef THIS
 

--- a/src/platform/linux/iotjs_module_blehcisocket-linux.c
+++ b/src/platform/linux/iotjs_module_blehcisocket-linux.c
@@ -297,8 +297,8 @@ void iotjs_blehcisocket_poll(THIS) {
       }
     }
 
-    iotjs_jval_t* jhcisocket = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
-    iotjs_jval_t jemit = iotjs_jval_get_property(jhcisocket, "emit");
+    iotjs_jval_t jhcisocket = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+    iotjs_jval_t jemit = iotjs_jval_get_property(&jhcisocket, "emit");
     IOTJS_ASSERT(iotjs_jval_is_function(&jemit));
 
     iotjs_jargs_t jargs = iotjs_jargs_create(2);
@@ -309,7 +309,7 @@ void iotjs_blehcisocket_poll(THIS) {
     iotjs_bufferwrap_copy(buf_wrap, data, (size_t)length);
     iotjs_jargs_append_jval(&jargs, &str);
     iotjs_jargs_append_jval(&jargs, &jbuf);
-    iotjs_jhelper_call_ok(&jemit, jhcisocket, &jargs);
+    iotjs_jhelper_call_ok(&jemit, &jhcisocket, &jargs);
 
     iotjs_jval_destroy(&str);
     iotjs_jval_destroy(&jbuf);
@@ -338,8 +338,8 @@ void iotjs_blehcisocket_write(THIS, char* data, size_t length) {
 void iotjs_blehcisocket_emitErrnoError(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_blehcisocket_t, blehcisocket);
 
-  iotjs_jval_t* jhcisocket = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
-  iotjs_jval_t jemit = iotjs_jval_get_property(jhcisocket, "emit");
+  iotjs_jval_t jhcisocket = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  iotjs_jval_t jemit = iotjs_jval_get_property(&jhcisocket, "emit");
   IOTJS_ASSERT(iotjs_jval_is_function(&jemit));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(2);
@@ -347,7 +347,7 @@ void iotjs_blehcisocket_emitErrnoError(THIS) {
   iotjs_jval_t jerror = iotjs_jval_create_error(strerror(errno));
   iotjs_jargs_append_jval(&jargs, &str);
   iotjs_jargs_append_jval(&jargs, &jerror);
-  iotjs_jhelper_call_ok(&jemit, jhcisocket, &jargs);
+  iotjs_jhelper_call_ok(&jemit, &jhcisocket, &jargs);
 
   iotjs_jval_destroy(&str);
   iotjs_jval_destroy(&jerror);

--- a/src/platform/linux/iotjs_module_gpio-linux.c
+++ b/src/platform/linux/iotjs_module_gpio-linux.c
@@ -79,11 +79,11 @@ static void gpio_set_value_fd(iotjs_gpio_t* gpio, int fd) {
 static void gpio_emit_change_event(iotjs_gpio_t* gpio) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_gpio_t, gpio);
 
-  iotjs_jval_t* jgpio = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
-  iotjs_jval_t jonChange = iotjs_jval_get_property(jgpio, "onChange");
+  iotjs_jval_t jgpio = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  iotjs_jval_t jonChange = iotjs_jval_get_property(&jgpio, "onChange");
   IOTJS_ASSERT(iotjs_jval_is_function(&jonChange));
 
-  iotjs_jhelper_call_ok(&jonChange, jgpio, iotjs_jargs_get_empty());
+  iotjs_jhelper_call_ok(&jonChange, &jgpio, iotjs_jargs_get_empty());
 
   iotjs_jval_destroy(&jonChange);
 }

--- a/src/platform/nuttx/iotjs_module_stm32f4dis-nuttx.c
+++ b/src/platform/nuttx/iotjs_module_stm32f4dis-nuttx.c
@@ -24,7 +24,7 @@
 
 
 #if ENABLE_MODULE_ADC
-static void iotjs_pin_initialize_adc(const iotjs_jval_t* jobj) {
+static void iotjs_pin_initialize_adc(iotjs_jval_t jobj) {
   unsigned int number_bit;
 
 // ADC pin name is "ADC.(number)_(timer)".
@@ -32,7 +32,7 @@ static void iotjs_pin_initialize_adc(const iotjs_jval_t* jobj) {
   number_bit = (GPIO_ADC##number##_IN##timer); \
   number_bit |= (ADC_NUMBER(number));          \
   number_bit |= (SYSIO_TIMER_NUMBER(timer));   \
-  iotjs_jval_set_property_number(jobj, "ADC" #number "_" #timer, number_bit);
+  iotjs_jval_set_property_number(&jobj, "ADC" #number "_" #timer, number_bit);
 
 #define SET_ADC_CONSTANT_NUMBER(number) \
   SET_ADC_CONSTANT(number, 0);          \
@@ -64,11 +64,11 @@ static void iotjs_pin_initialize_adc(const iotjs_jval_t* jobj) {
 
 #if ENABLE_MODULE_GPIO
 
-static void iotjs_pin_initialize_gpio(const iotjs_jval_t* jobj) {
+static void iotjs_pin_initialize_gpio(iotjs_jval_t jobj) {
 // Set GPIO pin from configuration bits of nuttx.
 // GPIO pin name is "P(port)(pin)".
-#define SET_GPIO_CONSTANT(port, pin)                   \
-  iotjs_jval_set_property_number(jobj, "P" #port #pin, \
+#define SET_GPIO_CONSTANT(port, pin)                    \
+  iotjs_jval_set_property_number(&jobj, "P" #port #pin, \
                                  (GPIO_PORT##port | GPIO_PIN##pin));
 
 #define SET_GPIO_CONSTANT_PORT(port) \
@@ -107,7 +107,7 @@ static void iotjs_pin_initialize_gpio(const iotjs_jval_t* jobj) {
 
 #if ENABLE_MODULE_PWM
 
-static void iotjs_pin_initialize_pwm(const iotjs_jval_t* jobj) {
+static void iotjs_pin_initialize_pwm(iotjs_jval_t jobj) {
   unsigned int timer_bit;
 
 // Set PWM pin from configuration bits of nuttx.
@@ -124,7 +124,7 @@ static void iotjs_pin_initialize_pwm(const iotjs_jval_t* jobj) {
 
 #define SET_GPIO_CONSTANT_TIM(timer)                     \
   iotjs_jval_t jtim##timer = iotjs_jval_create_object(); \
-  iotjs_jval_set_property_jval(jobj, "PWM" #timer, &jtim##timer);
+  iotjs_jval_set_property_jval(&jobj, "PWM" #timer, &jtim##timer);
 
 #define SET_GPIO_CONSTANT_TIM_1(timer) \
   SET_GPIO_CONSTANT_TIM(timer);        \
@@ -181,20 +181,20 @@ static void iotjs_pin_initialize_pwm(const iotjs_jval_t* jobj) {
 #endif /* ENABLE_MODULE_PWM */
 
 
-void iotjs_stm32f4dis_pin_initialize(const iotjs_jval_t* jobj) {
+void iotjs_stm32f4dis_pin_initialize(iotjs_jval_t jobj) {
   iotjs_jval_t jpin = iotjs_jval_create_object();
-  iotjs_jval_set_property_jval(jobj, "pin", &jpin);
+  iotjs_jval_set_property_jval(&jobj, "pin", &jpin);
 
 #if ENABLE_MODULE_ADC
-  iotjs_pin_initialize_adc(&jpin);
+  iotjs_pin_initialize_adc(jpin);
 #endif /* ENABLE_MODULE_ADC */
 
 #if ENABLE_MODULE_GPIO
-  iotjs_pin_initialize_gpio(&jpin);
+  iotjs_pin_initialize_gpio(jpin);
 #endif /* ENABLE_MODULE_GPIO */
 
 #if ENABLE_MODULE_PWM
-  iotjs_pin_initialize_pwm(&jpin);
+  iotjs_pin_initialize_pwm(jpin);
 #endif /* ENABLE_MODULE_PWM */
 
   iotjs_jval_destroy(&jpin);


### PR DESCRIPTION
Change 'iotjs_jval_t*' function parameters and locals to 'iotjs_jval_t' under modules directory (part 2). 

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com