### PR TITLE
Continue the 'iotjs_jval_t*' elimination. (#1223)

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -162,9 +162,9 @@ iotjs_jval_t* iotjs_jval_get_global_object() {
 }
 
 
-#define TYPE_CHECKER_BODY(jval_type)                        \
-  bool iotjs_jval_is_##jval_type(const iotjs_jval_t* val) { \
-    return jerry_value_is_##jval_type(*val);                \
+#define TYPE_CHECKER_BODY(jval_type)                 \
+  bool iotjs_jval_is_##jval_type(iotjs_jval_t val) { \
+    return jerry_value_is_##jval_type(val);          \
   }
 
 FOR_EACH_JVAL_TYPES(TYPE_CHECKER_BODY)
@@ -172,22 +172,22 @@ FOR_EACH_JVAL_TYPES(TYPE_CHECKER_BODY)
 #undef TYPE_CHECKER_BODY
 
 
-bool iotjs_jval_as_boolean(const iotjs_jval_t* jval) {
+bool iotjs_jval_as_boolean(iotjs_jval_t jval) {
   IOTJS_ASSERT(iotjs_jval_is_boolean(jval));
-  return jerry_get_boolean_value(*jval);
+  return jerry_get_boolean_value(jval);
 }
 
 
-double iotjs_jval_as_number(const iotjs_jval_t* jval) {
+double iotjs_jval_as_number(iotjs_jval_t jval) {
   IOTJS_ASSERT(iotjs_jval_is_number(jval));
-  return jerry_get_number_value(*jval);
+  return jerry_get_number_value(jval);
 }
 
 
-iotjs_string_t iotjs_jval_as_string(const iotjs_jval_t* jval) {
+iotjs_string_t iotjs_jval_as_string(iotjs_jval_t jval) {
   IOTJS_ASSERT(iotjs_jval_is_string(jval));
 
-  jerry_size_t size = jerry_get_string_size(*jval);
+  jerry_size_t size = jerry_get_string_size(jval);
 
   if (size == 0)
     return iotjs_string_create();
@@ -195,7 +195,7 @@ iotjs_string_t iotjs_jval_as_string(const iotjs_jval_t* jval) {
   char* buffer = iotjs_buffer_allocate(size + 1);
   jerry_char_t* jerry_buffer = (jerry_char_t*)(buffer);
 
-  size_t check = jerry_string_to_char_buffer(*jval, jerry_buffer, size);
+  size_t check = jerry_string_to_char_buffer(jval, jerry_buffer, size);
 
   IOTJS_ASSERT(check == size);
   buffer[size] = '\0';
@@ -206,20 +206,20 @@ iotjs_string_t iotjs_jval_as_string(const iotjs_jval_t* jval) {
 }
 
 
-const iotjs_jval_t* iotjs_jval_as_object(const iotjs_jval_t* jval) {
-  IOTJS_ASSERT(iotjs_jval_is_object(jval));
+iotjs_jval_t iotjs_jval_as_object(iotjs_jval_t jval) {
+  IOTJS_ASSERT(jerry_value_is_object(jval));
   return jval;
 }
 
 
-const iotjs_jval_t* iotjs_jval_as_array(const iotjs_jval_t* jval) {
-  IOTJS_ASSERT(iotjs_jval_is_array(jval));
+iotjs_jval_t iotjs_jval_as_array(iotjs_jval_t jval) {
+  IOTJS_ASSERT(jerry_value_is_array(jval));
   return jval;
 }
 
 
-const iotjs_jval_t* iotjs_jval_as_function(const iotjs_jval_t* jval) {
-  IOTJS_ASSERT(iotjs_jval_is_function(jval));
+iotjs_jval_t iotjs_jval_as_function(iotjs_jval_t jval) {
+  IOTJS_ASSERT(jerry_value_is_function(jval));
   return jval;
 }
 
@@ -241,7 +241,7 @@ bool iotjs_jval_set_prototype(const iotjs_jval_t* jobj, iotjs_jval_t* jproto) {
 
 void iotjs_jval_set_method(const iotjs_jval_t* jobj, const char* name,
                            iotjs_native_handler_t handler) {
-  IOTJS_ASSERT(iotjs_jval_is_object(jobj));
+  IOTJS_ASSERT(iotjs_jval_is_object(*jobj));
 
   iotjs_jval_t jfunc = iotjs_jval_create_function_with_dispatch(handler);
   iotjs_jval_set_property_jval(jobj, name, &jfunc);
@@ -251,7 +251,7 @@ void iotjs_jval_set_method(const iotjs_jval_t* jobj, const char* name,
 
 void iotjs_jval_set_property_jval(const iotjs_jval_t* jobj, const char* name,
                                   const iotjs_jval_t* val) {
-  IOTJS_ASSERT(iotjs_jval_is_object(jobj));
+  IOTJS_ASSERT(iotjs_jval_is_object(*jobj));
 
   jerry_value_t prop_name = jerry_create_string((const jerry_char_t*)(name));
   jerry_value_t value = iotjs_jval_as_raw(val);
@@ -306,7 +306,7 @@ void iotjs_jval_set_property_string_raw(const iotjs_jval_t* jobj,
 
 iotjs_jval_t iotjs_jval_get_property(const iotjs_jval_t* jobj,
                                      const char* name) {
-  IOTJS_ASSERT(iotjs_jval_is_object(jobj));
+  IOTJS_ASSERT(iotjs_jval_is_object(*jobj));
 
   jerry_value_t prop_name = jerry_create_string((const jerry_char_t*)(name));
   jerry_value_t res = jerry_get_property(*jobj, prop_name);
@@ -324,18 +324,18 @@ iotjs_jval_t iotjs_jval_get_property(const iotjs_jval_t* jobj,
 void iotjs_jval_set_object_native_handle(const iotjs_jval_t* jobj,
                                          uintptr_t ptr,
                                          JNativeInfoType* native_info) {
-  IOTJS_ASSERT(iotjs_jval_is_object(jobj));
+  IOTJS_ASSERT(iotjs_jval_is_object(*jobj));
 
   jerry_set_object_native_pointer(*jobj, (void*)ptr, native_info);
 }
 
 
-uintptr_t iotjs_jval_get_object_native_handle(const iotjs_jval_t* jobj) {
+uintptr_t iotjs_jval_get_object_native_handle(iotjs_jval_t jobj) {
   IOTJS_ASSERT(iotjs_jval_is_object(jobj));
 
   uintptr_t ptr = 0x0;
   JNativeInfoType* out_info;
-  jerry_get_object_native_pointer(*jobj, (void**)&ptr, &out_info);
+  jerry_get_object_native_pointer(jobj, (void**)&ptr, &out_info);
 
   return ptr;
 }
@@ -343,7 +343,7 @@ uintptr_t iotjs_jval_get_object_native_handle(const iotjs_jval_t* jobj) {
 
 uintptr_t iotjs_jval_get_object_from_jhandler(iotjs_jhandler_t* jhandler,
                                               JNativeInfoType* native_info) {
-  const iotjs_jval_t jval = *JHANDLER_GET_THIS(object);
+  const iotjs_jval_t jval = JHANDLER_GET_THIS(object);
 
   if (!jerry_value_is_object(jval)) {
     return 0;
@@ -396,7 +396,7 @@ uintptr_t iotjs_jval_get_arg_obj_from_jhandler(iotjs_jhandler_t* jhandler,
 
 void iotjs_jval_set_property_by_index(const iotjs_jval_t* jarr, uint32_t idx,
                                       const iotjs_jval_t* jval) {
-  IOTJS_ASSERT(iotjs_jval_is_object(jarr));
+  IOTJS_ASSERT(iotjs_jval_is_object(*jarr));
 
   jerry_value_t value = iotjs_jval_as_raw(jval);
   jerry_value_t ret_val = jerry_set_property_by_index(*jarr, idx, value);
@@ -407,7 +407,7 @@ void iotjs_jval_set_property_by_index(const iotjs_jval_t* jarr, uint32_t idx,
 
 iotjs_jval_t iotjs_jval_get_property_by_index(const iotjs_jval_t* jarr,
                                               uint32_t idx) {
-  IOTJS_ASSERT(iotjs_jval_is_object(jarr));
+  IOTJS_ASSERT(iotjs_jval_is_object(*jarr));
 
   jerry_value_t res = jerry_get_property_by_index(*jarr, idx);
 
@@ -423,7 +423,7 @@ iotjs_jval_t iotjs_jval_get_property_by_index(const iotjs_jval_t* jarr,
 iotjs_jval_t iotjs_jhelper_call(const iotjs_jval_t* jfunc,
                                 const iotjs_jval_t* jthis,
                                 const iotjs_jargs_t* jargs, bool* throws) {
-  IOTJS_ASSERT(iotjs_jval_is_object(jfunc));
+  IOTJS_ASSERT(iotjs_jval_is_object(*jfunc));
 
   jerry_value_t* jargv_ = NULL;
   jerry_length_t jargc_ = iotjs_jargs_length(jargs);
@@ -688,23 +688,23 @@ void iotjs_jhandler_destroy(iotjs_jhandler_t* jhandler) {
 }
 
 
-const iotjs_jval_t* iotjs_jhandler_get_function(iotjs_jhandler_t* jhandler) {
+iotjs_jval_t iotjs_jhandler_get_function(iotjs_jhandler_t* jhandler) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jhandler_t, jhandler);
-  return &_this->jfunc;
+  return _this->jfunc;
 }
 
 
-const iotjs_jval_t* iotjs_jhandler_get_this(iotjs_jhandler_t* jhandler) {
+iotjs_jval_t iotjs_jhandler_get_this(iotjs_jhandler_t* jhandler) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jhandler_t, jhandler);
-  return &_this->jthis;
+  return _this->jthis;
 }
 
 
-const iotjs_jval_t* iotjs_jhandler_get_arg(iotjs_jhandler_t* jhandler,
-                                           uint16_t index) {
+iotjs_jval_t iotjs_jhandler_get_arg(iotjs_jhandler_t* jhandler,
+                                    uint16_t index) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jhandler_t, jhandler);
   IOTJS_ASSERT(index < _this->jargc);
-  return &_this->jargv[index];
+  return _this->jargv[index];
 }
 
 
@@ -831,7 +831,7 @@ void iotjs_binding_initialize() {
   jfalse = iotjs_jval_create_raw(jerry_create_boolean(false));
   jglobal = iotjs_jval_create_raw(jerry_get_global_object());
 
-  IOTJS_ASSERT(iotjs_jval_is_object(&jglobal));
+  IOTJS_ASSERT(iotjs_jval_is_object(jglobal));
 
   iotjs_jargs_initialize_empty(&jargs_empty);
 

--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -94,22 +94,22 @@ void iotjs_jval_destroy(iotjs_jval_t* jval);
 #define THIS_JVAL const iotjs_jval_t* jval
 
 /* Type Checkers */
-bool iotjs_jval_is_undefined(THIS_JVAL);
-bool iotjs_jval_is_null(THIS_JVAL);
-bool iotjs_jval_is_boolean(THIS_JVAL);
-bool iotjs_jval_is_number(THIS_JVAL);
-bool iotjs_jval_is_string(THIS_JVAL);
-bool iotjs_jval_is_object(THIS_JVAL);
-bool iotjs_jval_is_array(THIS_JVAL);
-bool iotjs_jval_is_function(THIS_JVAL);
+bool iotjs_jval_is_undefined(iotjs_jval_t);
+bool iotjs_jval_is_null(iotjs_jval_t);
+bool iotjs_jval_is_boolean(iotjs_jval_t);
+bool iotjs_jval_is_number(iotjs_jval_t);
+bool iotjs_jval_is_string(iotjs_jval_t);
+bool iotjs_jval_is_object(iotjs_jval_t);
+bool iotjs_jval_is_array(iotjs_jval_t);
+bool iotjs_jval_is_function(iotjs_jval_t);
 
 /* Type Converters */
-bool iotjs_jval_as_boolean(THIS_JVAL);
-double iotjs_jval_as_number(THIS_JVAL);
-iotjs_string_t iotjs_jval_as_string(THIS_JVAL);
-const iotjs_jval_t* iotjs_jval_as_object(THIS_JVAL);
-const iotjs_jval_t* iotjs_jval_as_array(THIS_JVAL);
-const iotjs_jval_t* iotjs_jval_as_function(THIS_JVAL);
+bool iotjs_jval_as_boolean(iotjs_jval_t);
+double iotjs_jval_as_number(iotjs_jval_t);
+iotjs_string_t iotjs_jval_as_string(iotjs_jval_t);
+iotjs_jval_t iotjs_jval_as_object(iotjs_jval_t);
+iotjs_jval_t iotjs_jval_as_array(iotjs_jval_t);
+iotjs_jval_t iotjs_jval_as_function(iotjs_jval_t);
 
 /* Methods for General JavaScript Object */
 bool iotjs_jval_set_prototype(const iotjs_jval_t* jobj, iotjs_jval_t* jproto);
@@ -130,7 +130,7 @@ iotjs_jval_t iotjs_jval_get_property(THIS_JVAL, const char* name);
 
 void iotjs_jval_set_object_native_handle(THIS_JVAL, uintptr_t ptr,
                                          JNativeInfoType* native_info);
-uintptr_t iotjs_jval_get_object_native_handle(THIS_JVAL);
+uintptr_t iotjs_jval_get_object_native_handle(iotjs_jval_t jobj);
 uintptr_t iotjs_jval_get_object_from_jhandler(iotjs_jhandler_t* jhandler,
                                               JNativeInfoType* native_info);
 uintptr_t iotjs_jval_get_arg_obj_from_jhandler(iotjs_jhandler_t* jhandler,
@@ -203,10 +203,9 @@ void iotjs_jhandler_initialize(iotjs_jhandler_t* jhandler,
 
 void iotjs_jhandler_destroy(iotjs_jhandler_t* jhandler);
 
-const iotjs_jval_t* iotjs_jhandler_get_function(iotjs_jhandler_t* jhandler);
-const iotjs_jval_t* iotjs_jhandler_get_this(iotjs_jhandler_t* jhandler);
-const iotjs_jval_t* iotjs_jhandler_get_arg(iotjs_jhandler_t* jhandler,
-                                           uint16_t index);
+iotjs_jval_t iotjs_jhandler_get_function(iotjs_jhandler_t* jhandler);
+iotjs_jval_t iotjs_jhandler_get_this(iotjs_jhandler_t* jhandler);
+iotjs_jval_t iotjs_jhandler_get_arg(iotjs_jhandler_t* jhandler, uint16_t index);
 uint16_t iotjs_jhandler_get_arg_length(iotjs_jhandler_t* jhandler);
 
 void iotjs_jhandler_return_jval(iotjs_jhandler_t* jhandler,
@@ -287,11 +286,10 @@ static inline bool ge(uint16_t a, uint16_t b) {
 #define JHANDLER_GET_ARG(index, type) \
   iotjs_jval_as_##type(iotjs_jhandler_get_arg(jhandler, index))
 
-#define JHANDLER_GET_ARG_IF_EXIST(index, type)                          \
-  ((iotjs_jhandler_get_arg_length(jhandler) > index)                    \
-       ? (iotjs_jval_is_##type(iotjs_jhandler_get_arg(jhandler, index)) \
-              ? *iotjs_jhandler_get_arg(jhandler, index)                \
-              : *iotjs_jval_get_null())                                 \
+#define JHANDLER_GET_ARG_IF_EXIST(index, type)                           \
+  ((iotjs_jhandler_get_arg_length(jhandler) > index) &&                  \
+           iotjs_jval_is_##type(iotjs_jhandler_get_arg(jhandler, index)) \
+       ? iotjs_jhandler_get_arg(jhandler, index)                         \
        : *iotjs_jval_get_null())
 
 #define JHANDLER_GET_THIS(type) \
@@ -331,11 +329,11 @@ static inline bool ge(uint16_t a, uint16_t b) {
 #define DJHANDLER_GET_REQUIRED_CONF_VALUE(src, target, property, type)        \
   do {                                                                        \
     iotjs_jval_t jtmp = iotjs_jval_get_property(src, property);               \
-    if (iotjs_jval_is_undefined(&jtmp)) {                                     \
+    if (iotjs_jval_is_undefined(jtmp)) {                                      \
       JHANDLER_THROW(TYPE, "Missing argument, required " property);           \
       return;                                                                 \
-    } else if (iotjs_jval_is_##type(&jtmp))                                   \
-      target = iotjs_jval_as_##type(&jtmp);                                   \
+    } else if (iotjs_jval_is_##type(jtmp))                                    \
+      target = iotjs_jval_as_##type(jtmp);                                    \
     else {                                                                    \
       JHANDLER_THROW(TYPE,                                                    \
                      "Bad arguments, required " property " is not a " #type); \

--- a/src/iotjs_binding_helper.c
+++ b/src/iotjs_binding_helper.c
@@ -26,7 +26,7 @@ void iotjs_uncaught_exception(const iotjs_jval_t* jexception) {
   iotjs_jval_t jonuncaughtexception =
       iotjs_jval_get_property(&process,
                               IOTJS_MAGIC_STRING__ONUNCAUGHTEXCEPTION);
-  IOTJS_ASSERT(iotjs_jval_is_function(&jonuncaughtexception));
+  IOTJS_ASSERT(iotjs_jval_is_function(jonuncaughtexception));
 
   iotjs_jargs_t args = iotjs_jargs_create(1);
   iotjs_jargs_append_jval(&args, jexception);
@@ -55,7 +55,7 @@ void iotjs_process_emit_exit(int code) {
 
   iotjs_jval_t jexit =
       iotjs_jval_get_property(&process, IOTJS_MAGIC_STRING_EMITEXIT);
-  IOTJS_ASSERT(iotjs_jval_is_function(&jexit));
+  IOTJS_ASSERT(iotjs_jval_is_function(jexit));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(1);
   iotjs_jargs_append_number(&jargs, code);
@@ -85,15 +85,15 @@ bool iotjs_process_next_tick() {
 
   iotjs_jval_t jon_next_tick =
       iotjs_jval_get_property(&process, IOTJS_MAGIC_STRING__ONNEXTTICK);
-  IOTJS_ASSERT(iotjs_jval_is_function(&jon_next_tick));
+  IOTJS_ASSERT(iotjs_jval_is_function(jon_next_tick));
 
   iotjs_jval_t jres =
       iotjs_jhelper_call_ok(&jon_next_tick, iotjs_jval_get_undefined(),
                             iotjs_jargs_get_empty());
 
-  IOTJS_ASSERT(iotjs_jval_is_boolean(&jres));
+  IOTJS_ASSERT(iotjs_jval_is_boolean(jres));
 
-  bool ret = iotjs_jval_as_boolean(&jres);
+  bool ret = iotjs_jval_as_boolean(jres);
   iotjs_jval_destroy(&jres);
   iotjs_jval_destroy(&jon_next_tick);
 
@@ -136,9 +136,9 @@ int iotjs_process_exitcode() {
 
   iotjs_jval_t jexitcode =
       iotjs_jval_get_property(&process, IOTJS_MAGIC_STRING_EXITCODE);
-  IOTJS_ASSERT(iotjs_jval_is_number(&jexitcode));
+  IOTJS_ASSERT(iotjs_jval_is_number(jexitcode));
 
-  const int exitcode = (int)iotjs_jval_as_number(&jexitcode);
+  const int exitcode = (int)iotjs_jval_as_number(jexitcode);
   iotjs_jval_destroy(&jexitcode);
 
   return exitcode;

--- a/src/iotjs_handlewrap.c
+++ b/src/iotjs_handlewrap.c
@@ -56,7 +56,7 @@ iotjs_handlewrap_t* iotjs_handlewrap_from_handle(uv_handle_t* handle) {
 
 iotjs_handlewrap_t* iotjs_handlewrap_from_jobject(const iotjs_jval_t* jobject) {
   iotjs_handlewrap_t* handlewrap =
-      (iotjs_handlewrap_t*)(iotjs_jval_get_object_native_handle(jobject));
+      (iotjs_handlewrap_t*)(iotjs_jval_get_object_native_handle(*jobject));
   iotjs_handlewrap_validate(handlewrap);
   return handlewrap;
 }
@@ -69,7 +69,7 @@ uv_handle_t* iotjs_handlewrap_get_uv_handle(iotjs_handlewrap_t* handlewrap) {
 }
 
 
-iotjs_jval_t* iotjs_handlewrap_jobject(iotjs_handlewrap_t* handlewrap) {
+iotjs_jval_t iotjs_handlewrap_jobject(iotjs_handlewrap_t* handlewrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_handlewrap_t, handlewrap);
   iotjs_handlewrap_validate(handlewrap);
   return iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
@@ -90,7 +90,8 @@ static void iotjs_handlewrap_on_close(iotjs_handlewrap_t* handlewrap) {
 
   // Decrease ref count of Javascript object. From now the object can be
   // reclaimed.
-  iotjs_jval_destroy(iotjs_jobjectwrap_jobject(&_this->jobjectwrap));
+  iotjs_jval_t jval = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  iotjs_jval_destroy(&jval);
 }
 
 

--- a/src/iotjs_handlewrap.h
+++ b/src/iotjs_handlewrap.h
@@ -64,7 +64,7 @@ iotjs_handlewrap_t* iotjs_handlewrap_from_handle(uv_handle_t* handle);
 iotjs_handlewrap_t* iotjs_handlewrap_from_jobject(const iotjs_jval_t* jobject);
 
 uv_handle_t* iotjs_handlewrap_get_uv_handle(iotjs_handlewrap_t* handlewrap);
-iotjs_jval_t* iotjs_handlewrap_jobject(iotjs_handlewrap_t* handlewrap);
+iotjs_jval_t iotjs_handlewrap_jobject(iotjs_handlewrap_t* handlewrap);
 
 void iotjs_handlewrap_validate(iotjs_handlewrap_t* handlewrap);
 

--- a/src/iotjs_module.c
+++ b/src/iotjs_module.c
@@ -48,8 +48,8 @@ void iotjs_module_list_init() {
 #undef INIT_MODULE_LIST
 
 
-#define CLENUP_MODULE_LIST(upper, Camel, lower)                   \
-  if (!iotjs_jval_is_undefined(&modules[MODULE_##upper].jmodule)) \
+#define CLENUP_MODULE_LIST(upper, Camel, lower)                  \
+  if (!iotjs_jval_is_undefined(modules[MODULE_##upper].jmodule)) \
     iotjs_jval_destroy(&modules[MODULE_##upper].jmodule);
 
 void iotjs_module_list_cleanup() {
@@ -63,7 +63,7 @@ const iotjs_jval_t* iotjs_module_initialize_if_necessary(ModuleKind kind) {
   IOTJS_ASSERT(kind < MODULE_COUNT);
   IOTJS_ASSERT(&modules[kind].fn_register != NULL);
 
-  if (iotjs_jval_is_undefined(&modules[kind].jmodule)) {
+  if (iotjs_jval_is_undefined(modules[kind].jmodule)) {
     modules[kind].jmodule = modules[kind].fn_register();
   }
 
@@ -73,6 +73,6 @@ const iotjs_jval_t* iotjs_module_initialize_if_necessary(ModuleKind kind) {
 
 const iotjs_jval_t* iotjs_module_get(ModuleKind kind) {
   IOTJS_ASSERT(kind < MODULE_COUNT);
-  IOTJS_ASSERT(!iotjs_jval_is_undefined(&modules[kind].jmodule));
+  IOTJS_ASSERT(!iotjs_jval_is_undefined(modules[kind].jmodule));
   return &modules[kind].jmodule;
 }

--- a/src/iotjs_objectwrap.c
+++ b/src/iotjs_objectwrap.c
@@ -22,7 +22,7 @@ void iotjs_jobjectwrap_initialize(iotjs_jobjectwrap_t* jobjectwrap,
                                   JNativeInfoType* native_info) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_jobjectwrap_t, jobjectwrap);
 
-  IOTJS_ASSERT(iotjs_jval_is_object(jobject));
+  IOTJS_ASSERT(iotjs_jval_is_object(*jobject));
 
   // This wrapper holds pointer to the javascript object but never increases
   // reference count.
@@ -42,9 +42,9 @@ void iotjs_jobjectwrap_destroy(iotjs_jobjectwrap_t* jobjectwrap) {
 }
 
 
-iotjs_jval_t* iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap) {
+iotjs_jval_t iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_jobjectwrap_t, jobjectwrap);
-  iotjs_jval_t* jobject = &_this->jobject;
+  iotjs_jval_t jobject = _this->jobject;
   IOTJS_ASSERT((uintptr_t)jobjectwrap ==
                iotjs_jval_get_object_native_handle(jobject));
   IOTJS_ASSERT(iotjs_jval_is_object(jobject));
@@ -55,7 +55,7 @@ iotjs_jval_t* iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap) {
 iotjs_jobjectwrap_t* iotjs_jobjectwrap_from_jobject(
     const iotjs_jval_t* jobject) {
   iotjs_jobjectwrap_t* wrap =
-      (iotjs_jobjectwrap_t*)(iotjs_jval_get_object_native_handle(jobject));
+      (iotjs_jobjectwrap_t*)(iotjs_jval_get_object_native_handle(*jobject));
   IOTJS_ASSERT(iotjs_jval_is_object(iotjs_jobjectwrap_jobject(wrap)));
   return wrap;
 }

--- a/src/iotjs_objectwrap.h
+++ b/src/iotjs_objectwrap.h
@@ -32,7 +32,7 @@ void iotjs_jobjectwrap_initialize(iotjs_jobjectwrap_t* jobjectwrap,
 
 void iotjs_jobjectwrap_destroy(iotjs_jobjectwrap_t* jobjectwrap);
 
-iotjs_jval_t* iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap);
+iotjs_jval_t iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap);
 iotjs_jobjectwrap_t* iotjs_jobjectwrap_from_jobject(
     const iotjs_jval_t* jobject);
 

--- a/src/iotjs_reqwrap.c
+++ b/src/iotjs_reqwrap.c
@@ -21,7 +21,7 @@ void iotjs_reqwrap_initialize(iotjs_reqwrap_t* reqwrap,
                               const iotjs_jval_t* jcallback,
                               uv_req_t* request) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_reqwrap_t, reqwrap);
-  IOTJS_ASSERT(iotjs_jval_is_function(jcallback));
+  IOTJS_ASSERT(iotjs_jval_is_function(*jcallback));
   _this->jcallback = iotjs_jval_create_copied(jcallback);
   _this->request = request;
   _this->request->data = reqwrap;

--- a/src/modules/iotjs_module_adc.c
+++ b/src/modules/iotjs_module_adc.c
@@ -21,13 +21,13 @@
 static JNativeInfoType this_module_native_info = {.free_cb = NULL };
 
 
-static iotjs_adc_t* iotjs_adc_instance_from_jval(const iotjs_jval_t jadc);
+static iotjs_adc_t* iotjs_adc_instance_from_jval(iotjs_jval_t jadc);
 
 
-static iotjs_adc_t* iotjs_adc_create(const iotjs_jval_t jadc) {
+static iotjs_adc_t* iotjs_adc_create(const iotjs_jval_t* jadc) {
   iotjs_adc_t* adc = IOTJS_ALLOC(iotjs_adc_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_adc_t, adc);
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, &jadc,
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jadc,
                                &this_module_native_info);
 
   return adc;
@@ -48,11 +48,11 @@ static void iotjs_adc_destroy(iotjs_adc_t* adc) {
 
 
 static iotjs_adc_reqwrap_t* iotjs_adc_reqwrap_create(
-    const iotjs_jval_t jcallback, iotjs_adc_t* adc, AdcOp op) {
+    const iotjs_jval_t* jcallback, iotjs_adc_t* adc, AdcOp op) {
   iotjs_adc_reqwrap_t* adc_reqwrap = IOTJS_ALLOC(iotjs_adc_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_adc_reqwrap_t, adc_reqwrap);
 
-  iotjs_reqwrap_initialize(&_this->reqwrap, &jcallback, (uv_req_t*)&_this->req);
+  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
 
   _this->req_data.op = op;
   _this->adc_instance = adc;
@@ -78,14 +78,14 @@ static uv_work_t* iotjs_adc_reqwrap_req(THIS) {
 }
 
 
-static iotjs_jval_t iotjs_adc_reqwrap_jcallback(THIS) {
+static const iotjs_jval_t* iotjs_adc_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_adc_reqwrap_t, adc_reqwrap);
-  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 
-static iotjs_adc_t* iotjs_adc_instance_from_jval(const iotjs_jval_t jadc) {
-  uintptr_t handle = iotjs_jval_get_object_native_handle(&jadc);
+static iotjs_adc_t* iotjs_adc_instance_from_jval(iotjs_jval_t jadc) {
+  uintptr_t handle = iotjs_jval_get_object_native_handle(jadc);
   return (iotjs_adc_t*)handle;
 }
 
@@ -153,8 +153,8 @@ static void iotjs_adc_after_work(uv_work_t* work_req, int status) {
     }
   }
 
-  const iotjs_jval_t jcallback = iotjs_adc_reqwrap_jcallback(req_wrap);
-  iotjs_make_callback(&jcallback, iotjs_jval_get_undefined(), &jargs);
+  const iotjs_jval_t* jcallback = iotjs_adc_reqwrap_jcallback(req_wrap);
+  iotjs_make_callback(jcallback, iotjs_jval_get_undefined(), &jargs);
 
   iotjs_jargs_destroy(&jargs);
 
@@ -206,8 +206,8 @@ JHANDLER_FUNCTION(AdcConstructor) {
   DJHANDLER_CHECK_THIS(object);
 
   // Create ADC object
-  const iotjs_jval_t jadc = *JHANDLER_GET_THIS(object);
-  iotjs_adc_t* adc = iotjs_adc_create(jadc);
+  const iotjs_jval_t jadc = JHANDLER_GET_THIS(object);
+  iotjs_adc_t* adc = iotjs_adc_create(&jadc);
   IOTJS_ASSERT(adc == iotjs_adc_instance_from_jval(jadc));
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_adc_t, adc);
 
@@ -226,9 +226,9 @@ JHANDLER_FUNCTION(AdcConstructor) {
 #endif
 
   if (iotjs_jhandler_get_arg_length(jhandler) > 1) {
-    const iotjs_jval_t jcallback = *iotjs_jhandler_get_arg(jhandler, 1);
-    if (iotjs_jval_is_function(&jcallback)) {
-      ADC_ASYNC(open, adc, jcallback, kAdcOpOpen);
+    const iotjs_jval_t jcallback = iotjs_jhandler_get_arg(jhandler, 1);
+    if (iotjs_jval_is_function(jcallback)) {
+      ADC_ASYNC(open, adc, &jcallback, kAdcOpOpen);
     } else {
       JHANDLER_THROW(TYPE, "Bad arguments - callback should be Function");
       return;
@@ -236,7 +236,7 @@ JHANDLER_FUNCTION(AdcConstructor) {
   } else {
     iotjs_jval_t jdummycallback =
         iotjs_jval_create_function(&iotjs_jval_dummy_function);
-    ADC_ASYNC(open, adc, jdummycallback, kAdcOpOpen);
+    ADC_ASYNC(open, adc, &jdummycallback, kAdcOpOpen);
     iotjs_jval_destroy(&jdummycallback);
   }
 }
@@ -246,12 +246,12 @@ JHANDLER_FUNCTION(Read) {
   JHANDLER_DECLARE_THIS_PTR(adc, adc);
   DJHANDLER_CHECK_ARG_IF_EXIST(0, function);
 
-  iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
 
   if (jerry_value_is_null(jcallback)) {
     JHANDLER_THROW(TYPE, "Bad arguments - callback required");
   } else {
-    ADC_ASYNC(read, adc, jcallback, kAdcOpRead);
+    ADC_ASYNC(read, adc, &jcallback, kAdcOpRead);
   }
 }
 
@@ -275,10 +275,10 @@ JHANDLER_FUNCTION(Close) {
   if (jerry_value_is_null(jcallback)) {
     iotjs_jval_t jdummycallback =
         iotjs_jval_create_function(&iotjs_jval_dummy_function);
-    ADC_ASYNC(close, adc, jdummycallback, kAdcOpClose);
+    ADC_ASYNC(close, adc, &jdummycallback, kAdcOpClose);
     iotjs_jval_destroy(&jdummycallback);
   } else {
-    ADC_ASYNC(close, adc, jcallback, kAdcOpClose);
+    ADC_ASYNC(close, adc, &jcallback, kAdcOpClose);
   }
 
   iotjs_jhandler_return_null(jhandler);

--- a/src/modules/iotjs_module_blehcisocket.c
+++ b/src/modules/iotjs_module_blehcisocket.c
@@ -61,8 +61,9 @@ iotjs_blehcisocket_t* iotjs_blehcisocket_create(iotjs_jval_t jble) {
 }
 
 
-iotjs_blehcisocket_t* iotjs_blehcisocket_instance_from_jval(iotjs_jval_t jble) {
-  iotjs_jobjectwrap_t* jobjectwrap = iotjs_jobjectwrap_from_jobject(&jble);
+iotjs_blehcisocket_t* iotjs_blehcisocket_instance_from_jval(
+    const iotjs_jval_t* jble) {
+  iotjs_jobjectwrap_t* jobjectwrap = iotjs_jobjectwrap_from_jobject(jble);
   return (iotjs_blehcisocket_t*)jobjectwrap;
 }
 
@@ -93,9 +94,9 @@ JHANDLER_FUNCTION(BindRaw) {
   int devId = 0;
   int* pDevId = NULL;
 
-  iotjs_jval_t raw = *iotjs_jhandler_get_arg(jhandler, 0);
-  if (iotjs_jval_is_number(&raw)) {
-    devId = iotjs_jval_as_number(&raw);
+  iotjs_jval_t raw = iotjs_jhandler_get_arg(jhandler, 0);
+  if (iotjs_jval_is_number(raw)) {
+    devId = iotjs_jval_as_number(raw);
     pDevId = &devId;
   }
 
@@ -143,7 +144,7 @@ JHANDLER_FUNCTION(SetFilter) {
   DJHANDLER_CHECK_ARGS(1, object);
 
   iotjs_bufferwrap_t* buffer =
-      iotjs_bufferwrap_from_jbuffer(*JHANDLER_GET_ARG(0, object));
+      iotjs_bufferwrap_from_jbuffer(JHANDLER_GET_ARG(0, object));
 
   iotjs_blehcisocket_setFilter(blehcisocket, iotjs_bufferwrap_buffer(buffer),
                                iotjs_bufferwrap_length(buffer));
@@ -167,7 +168,7 @@ JHANDLER_FUNCTION(Write) {
   DJHANDLER_CHECK_ARGS(1, object);
 
   iotjs_bufferwrap_t* buffer =
-      iotjs_bufferwrap_from_jbuffer(*JHANDLER_GET_ARG(0, object));
+      iotjs_bufferwrap_from_jbuffer(JHANDLER_GET_ARG(0, object));
 
   iotjs_blehcisocket_write(blehcisocket, iotjs_bufferwrap_buffer(buffer),
                            iotjs_bufferwrap_length(buffer));
@@ -181,11 +182,11 @@ JHANDLER_FUNCTION(BleHciSocketCons) {
   DJHANDLER_CHECK_ARGS(0);
 
   // Create object
-  iotjs_jval_t jblehcisocket = *JHANDLER_GET_THIS(object);
+  iotjs_jval_t jblehcisocket = JHANDLER_GET_THIS(object);
   iotjs_blehcisocket_t* blehcisocket = iotjs_blehcisocket_create(jblehcisocket);
   IOTJS_ASSERT(blehcisocket ==
                (iotjs_blehcisocket_t*)(iotjs_jval_get_object_native_handle(
-                   &jblehcisocket)));
+                   jblehcisocket)));
 }
 
 

--- a/src/modules/iotjs_module_blehcisocket.h
+++ b/src/modules/iotjs_module_blehcisocket.h
@@ -59,7 +59,8 @@ typedef struct {
 
 
 iotjs_blehcisocket_t* iotjs_blehcisocket_create(iotjs_jval_t jble);
-iotjs_blehcisocket_t* iotjs_blehcisocket_instance_from_jval(iotjs_jval_t jble);
+iotjs_blehcisocket_t* iotjs_blehcisocket_instance_from_jval(
+    const iotjs_jval_t* jble);
 
 
 void iotjs_blehcisocket_initialize(THIS);

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -42,7 +42,7 @@ iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t jbuiltin,
 
   IOTJS_ASSERT(
       bufferwrap ==
-      (iotjs_bufferwrap_t*)(iotjs_jval_get_object_native_handle(&jbuiltin)));
+      (iotjs_bufferwrap_t*)(iotjs_jval_get_object_native_handle(jbuiltin)));
 
   return bufferwrap;
 }
@@ -60,16 +60,16 @@ static void iotjs_bufferwrap_destroy(iotjs_bufferwrap_t* bufferwrap) {
 
 iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuiltin(
     const iotjs_jval_t jbuiltin) {
-  IOTJS_ASSERT(iotjs_jval_is_object(&jbuiltin));
+  IOTJS_ASSERT(iotjs_jval_is_object(jbuiltin));
   iotjs_bufferwrap_t* buffer =
-      (iotjs_bufferwrap_t*)iotjs_jval_get_object_native_handle(&jbuiltin);
+      (iotjs_bufferwrap_t*)iotjs_jval_get_object_native_handle(jbuiltin);
   IOTJS_ASSERT(buffer != NULL);
   return buffer;
 }
 
 
 iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuffer(const iotjs_jval_t jbuffer) {
-  IOTJS_ASSERT(iotjs_jval_is_object(&jbuffer));
+  IOTJS_ASSERT(iotjs_jval_is_object(jbuffer));
   iotjs_jval_t jbuiltin =
       iotjs_jval_get_property(&jbuffer, IOTJS_MAGIC_STRING__BUILTIN);
   iotjs_bufferwrap_t* buffer = iotjs_bufferwrap_from_jbuiltin(jbuiltin);
@@ -80,7 +80,7 @@ iotjs_bufferwrap_t* iotjs_bufferwrap_from_jbuffer(const iotjs_jval_t jbuffer) {
 
 iotjs_jval_t iotjs_bufferwrap_jbuiltin(iotjs_bufferwrap_t* bufferwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_bufferwrap_t, bufferwrap);
-  return *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  return iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
 }
 
 
@@ -103,7 +103,7 @@ size_t iotjs_bufferwrap_length(iotjs_bufferwrap_t* bufferwrap) {
   iotjs_jval_t jbuf = iotjs_bufferwrap_jbuffer(bufferwrap);
   iotjs_jval_t jlength =
       iotjs_jval_get_property(&jbuf, IOTJS_MAGIC_STRING_LENGTH);
-  size_t length = iotjs_jval_as_number(&jlength);
+  size_t length = iotjs_jval_as_number(jlength);
   IOTJS_ASSERT(length == _this->length);
   iotjs_jval_destroy(&jbuf);
   iotjs_jval_destroy(&jlength);
@@ -217,14 +217,14 @@ iotjs_jval_t iotjs_bufferwrap_create_buffer(size_t len) {
 
   iotjs_jval_t jbuffer =
       iotjs_jval_get_property(&jglobal, IOTJS_MAGIC_STRING_BUFFER);
-  IOTJS_ASSERT(iotjs_jval_is_function(&jbuffer));
+  IOTJS_ASSERT(iotjs_jval_is_function(jbuffer));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(1);
   iotjs_jargs_append_number(&jargs, len);
 
   iotjs_jval_t jres =
       iotjs_jhelper_call_ok(&jbuffer, iotjs_jval_get_undefined(), &jargs);
-  IOTJS_ASSERT(iotjs_jval_is_object(&jres));
+  IOTJS_ASSERT(iotjs_jval_is_object(jres));
 
   iotjs_jargs_destroy(&jargs);
   iotjs_jval_destroy(&jbuffer);
@@ -237,8 +237,8 @@ JHANDLER_FUNCTION(Buffer) {
   DJHANDLER_CHECK_THIS(object);
   DJHANDLER_CHECK_ARGS(2, object, number);
 
-  const iotjs_jval_t jbuiltin = *JHANDLER_GET_THIS(object);
-  const iotjs_jval_t jbuffer = *JHANDLER_GET_ARG(0, object);
+  const iotjs_jval_t jbuiltin = JHANDLER_GET_THIS(object);
+  const iotjs_jval_t jbuffer = JHANDLER_GET_ARG(0, object);
   size_t length = JHANDLER_GET_ARG(1, number);
 
   iotjs_jval_set_property_jval(&jbuiltin, IOTJS_MAGIC_STRING__BUFFER, &jbuffer);
@@ -260,7 +260,7 @@ JHANDLER_FUNCTION(Copy) {
   JHANDLER_DECLARE_THIS_PTR(bufferwrap, src_buffer_wrap);
   DJHANDLER_CHECK_ARGS(4, object, number, number, number);
 
-  const iotjs_jval_t jdst_buffer = *JHANDLER_GET_ARG(0, object);
+  const iotjs_jval_t jdst_buffer = JHANDLER_GET_ARG(0, object);
   iotjs_bufferwrap_t* dst_buffer_wrap =
       iotjs_bufferwrap_from_jbuffer(jdst_buffer);
 

--- a/src/modules/iotjs_module_dns.c
+++ b/src/modules/iotjs_module_dns.c
@@ -172,7 +172,7 @@ JHANDLER_FUNCTION(GetAddrInfo) {
   int option = JHANDLER_GET_ARG(1, number);
   int flags = JHANDLER_GET_ARG(2, number);
   int error = 0;
-  const iotjs_jval_t jcallback = *JHANDLER_GET_ARG(3, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG(3, function);
 
   int family;
   if (option == 0) {

--- a/src/modules/iotjs_module_fs.c
+++ b/src/modules/iotjs_module_fs.c
@@ -50,7 +50,7 @@ static void AfterAsync(uv_fs_t* req) {
   IOTJS_ASSERT(&req_wrap->req == req);
 
   const iotjs_jval_t cb = *iotjs_reqwrap_jcallback(&req_wrap->reqwrap);
-  IOTJS_ASSERT(iotjs_jval_is_function(&cb));
+  IOTJS_ASSERT(iotjs_jval_is_function(cb));
 
   iotjs_jargs_t jarg = iotjs_jargs_create(2);
   if (req->result < 0) {
@@ -237,7 +237,7 @@ JHANDLER_FUNCTION(Read) {
   const iotjs_environment_t* env = iotjs_environment_get();
 
   int fd = JHANDLER_GET_ARG(0, number);
-  const iotjs_jval_t jbuffer = *JHANDLER_GET_ARG(1, object);
+  const iotjs_jval_t jbuffer = JHANDLER_GET_ARG(1, object);
   size_t offset = JHANDLER_GET_ARG(2, number);
   size_t length = JHANDLER_GET_ARG(3, number);
   int position = JHANDLER_GET_ARG(4, number);
@@ -276,7 +276,7 @@ JHANDLER_FUNCTION(Write) {
   const iotjs_environment_t* env = iotjs_environment_get();
 
   int fd = JHANDLER_GET_ARG(0, number);
-  const iotjs_jval_t jbuffer = *JHANDLER_GET_ARG(1, object);
+  const iotjs_jval_t jbuffer = JHANDLER_GET_ARG(1, object);
   size_t offset = JHANDLER_GET_ARG(2, number);
   size_t length = JHANDLER_GET_ARG(3, number);
   int position = JHANDLER_GET_ARG(4, number);
@@ -308,11 +308,11 @@ JHANDLER_FUNCTION(Write) {
 
 
 iotjs_jval_t MakeStatObject(uv_stat_t* statbuf) {
-  const iotjs_jval_t fs = *iotjs_module_get(MODULE_FS);
+  const iotjs_jval_t* fs = iotjs_module_get(MODULE_FS);
 
   iotjs_jval_t stat_prototype =
-      iotjs_jval_get_property(&fs, IOTJS_MAGIC_STRING_STATS);
-  IOTJS_ASSERT(iotjs_jval_is_object(&stat_prototype));
+      iotjs_jval_get_property(fs, IOTJS_MAGIC_STRING_STATS);
+  IOTJS_ASSERT(iotjs_jval_is_object(stat_prototype));
 
   iotjs_jval_t jstat = iotjs_jval_create_object();
   iotjs_jval_set_prototype(&jstat, &stat_prototype);
@@ -482,10 +482,10 @@ JHANDLER_FUNCTION(ReadDir) {
 
 static void StatsIsTypeOf(iotjs_jhandler_t* jhandler, int type) {
   DJHANDLER_CHECK_THIS(object);
-  const iotjs_jval_t stats = *JHANDLER_GET_THIS(object);
+  const iotjs_jval_t stats = JHANDLER_GET_THIS(object);
   iotjs_jval_t mode = iotjs_jval_get_property(&stats, IOTJS_MAGIC_STRING_MODE);
 
-  int mode_number = (int)iotjs_jval_as_number(&mode);
+  int mode_number = (int)iotjs_jval_as_number(mode);
 
   iotjs_jval_destroy(&mode);
 

--- a/src/modules/iotjs_module_gpio.c
+++ b/src/modules/iotjs_module_gpio.c
@@ -21,14 +21,14 @@
 #include <stdio.h>
 
 
-static iotjs_gpio_t* iotjs_gpio_instance_from_jval(const iotjs_jval_t jgpio);
+static iotjs_gpio_t* iotjs_gpio_instance_from_jval(iotjs_jval_t jgpio);
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(gpio);
 
 
-static iotjs_gpio_t* iotjs_gpio_create(iotjs_jval_t jgpio) {
+static iotjs_gpio_t* iotjs_gpio_create(const iotjs_jval_t* jgpio) {
   iotjs_gpio_t* gpio = IOTJS_ALLOC(iotjs_gpio_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_gpio_t, gpio);
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, &jgpio,
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jgpio,
                                &this_module_native_info);
 
   iotjs_gpio_platform_create(_this);
@@ -47,13 +47,12 @@ static void iotjs_gpio_destroy(iotjs_gpio_t* gpio) {
 #define THIS iotjs_gpio_reqwrap_t* gpio_reqwrap
 
 
-static iotjs_gpio_reqwrap_t* iotjs_gpio_reqwrap_create(iotjs_jval_t jcallback,
-                                                       iotjs_gpio_t* gpio,
-                                                       GpioOp op) {
+static iotjs_gpio_reqwrap_t* iotjs_gpio_reqwrap_create(
+    const iotjs_jval_t* jcallback, iotjs_gpio_t* gpio, GpioOp op) {
   iotjs_gpio_reqwrap_t* gpio_reqwrap = IOTJS_ALLOC(iotjs_gpio_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_gpio_reqwrap_t, gpio_reqwrap);
 
-  iotjs_reqwrap_initialize(&_this->reqwrap, &jcallback, (uv_req_t*)&_this->req);
+  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
 
   _this->req_data.op = op;
   _this->gpio_instance = gpio;
@@ -80,15 +79,16 @@ static uv_work_t* iotjs_gpio_reqwrap_req(THIS) {
 }
 
 
-static iotjs_jval_t iotjs_gpio_reqwrap_jcallback(THIS) {
+static const iotjs_jval_t* iotjs_gpio_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_gpio_reqwrap_t, gpio_reqwrap);
-  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 
-static iotjs_gpio_t* iotjs_gpio_instance_from_jval(const iotjs_jval_t jgpio) {
-  uintptr_t handle = iotjs_jval_get_object_native_handle(&jgpio);
-  return (iotjs_gpio_t*)handle;
+static iotjs_gpio_t* iotjs_gpio_instance_from_jval(iotjs_jval_t jgpio) {
+  iotjs_gpio_t* gpio =
+      (iotjs_gpio_t*)(iotjs_jval_get_object_native_handle(jgpio));
+  return gpio;
 }
 
 
@@ -194,8 +194,8 @@ static void iotjs_gpio_after_worker(uv_work_t* work_req, int status) {
     }
   }
 
-  iotjs_jval_t jcallback = iotjs_gpio_reqwrap_jcallback(req_wrap);
-  iotjs_make_callback(&jcallback, iotjs_jval_get_undefined(), &jargs);
+  const iotjs_jval_t* jcallback = iotjs_gpio_reqwrap_jcallback(req_wrap);
+  iotjs_make_callback(jcallback, iotjs_jval_get_undefined(), &jargs);
 
   iotjs_jargs_destroy(&jargs);
 
@@ -204,27 +204,27 @@ static void iotjs_gpio_after_worker(uv_work_t* work_req, int status) {
 
 
 static void gpio_set_configurable(iotjs_gpio_t* gpio,
-                                  iotjs_jval_t jconfigurable) {
+                                  const iotjs_jval_t jconfigurable) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_gpio_t, gpio);
 
   iotjs_jval_t jpin =
       iotjs_jval_get_property(&jconfigurable, IOTJS_MAGIC_STRING_PIN);
-  _this->pin = iotjs_jval_as_number(&jpin);
+  _this->pin = iotjs_jval_as_number(jpin);
   iotjs_jval_destroy(&jpin);
 
   iotjs_jval_t jdirection =
       iotjs_jval_get_property(&jconfigurable, IOTJS_MAGIC_STRING_DIRECTION);
-  _this->direction = (GpioDirection)iotjs_jval_as_number(&jdirection);
+  _this->direction = (GpioDirection)iotjs_jval_as_number(jdirection);
   iotjs_jval_destroy(&jdirection);
 
   iotjs_jval_t jmode =
       iotjs_jval_get_property(&jconfigurable, IOTJS_MAGIC_STRING_MODE);
-  _this->mode = (GpioMode)iotjs_jval_as_number(&jmode);
+  _this->mode = (GpioMode)iotjs_jval_as_number(jmode);
   iotjs_jval_destroy(&jmode);
 
   iotjs_jval_t jedge =
       iotjs_jval_get_property(&jconfigurable, IOTJS_MAGIC_STRING_EDGE);
-  _this->edge = (GpioMode)iotjs_jval_as_number(&jedge);
+  _this->edge = (GpioMode)iotjs_jval_as_number(jedge);
   iotjs_jval_destroy(&jedge);
 }
 
@@ -258,14 +258,14 @@ JHANDLER_FUNCTION(GpioConstructor) {
   DJHANDLER_CHECK_ARGS(2, object, function);
 
   // Create GPIO object
-  const iotjs_jval_t jgpio = *JHANDLER_GET_THIS(object);
-  iotjs_gpio_t* gpio = iotjs_gpio_create(jgpio);
+  const iotjs_jval_t jgpio = JHANDLER_GET_THIS(object);
+  iotjs_gpio_t* gpio = iotjs_gpio_create(&jgpio);
   IOTJS_ASSERT(gpio == iotjs_gpio_instance_from_jval(jgpio));
 
-  gpio_set_configurable(gpio, *JHANDLER_GET_ARG(0, object));
+  gpio_set_configurable(gpio, JHANDLER_GET_ARG(0, object));
 
-  const iotjs_jval_t jcallback = *JHANDLER_GET_ARG(1, function);
-  GPIO_ASYNC(open, gpio, jcallback, kGpioOpOpen);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG(1, function);
+  GPIO_ASYNC(open, gpio, &jcallback, kGpioOpOpen);
 }
 
 
@@ -279,7 +279,7 @@ JHANDLER_FUNCTION(Write) {
   bool value = JHANDLER_GET_ARG(0, boolean);
 
   if (!jerry_value_is_null(jcallback)) {
-    GPIO_ASYNC_WITH_VALUE(write, gpio, jcallback, kGpioOpWrite, value);
+    GPIO_ASYNC_WITH_VALUE(write, gpio, &jcallback, kGpioOpWrite, value);
   } else {
     if (!iotjs_gpio_write(gpio, value)) {
       JHANDLER_THROW(COMMON, "GPIO WriteSync Error");
@@ -298,7 +298,7 @@ JHANDLER_FUNCTION(Read) {
   const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
 
   if (!jerry_value_is_null(jcallback)) {
-    GPIO_ASYNC(read, gpio, jcallback, kGpioOpRead);
+    GPIO_ASYNC(read, gpio, &jcallback, kGpioOpRead);
     iotjs_jhandler_return_null(jhandler);
   } else {
     int value = iotjs_gpio_read(gpio);
@@ -317,7 +317,7 @@ JHANDLER_FUNCTION(Close) {
   const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
 
   if (!jerry_value_is_null(jcallback)) {
-    GPIO_ASYNC(close, gpio, jcallback, kGpioOpClose);
+    GPIO_ASYNC(close, gpio, &jcallback, kGpioOpClose);
   } else {
     if (!iotjs_gpio_close(gpio)) {
       JHANDLER_THROW(COMMON, "GPIO CloseSync Error");

--- a/src/modules/iotjs_module_httpparser.c
+++ b/src/modules/iotjs_module_httpparser.c
@@ -131,10 +131,10 @@ static iotjs_jval_t iotjs_httpparserwrap_make_header(
 
 static void iotjs_httpparserwrap_flush(iotjs_httpparserwrap_t* httpparserwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, httpparserwrap);
-  const iotjs_jval_t jobj = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  const iotjs_jval_t jobj = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t func =
       iotjs_jval_get_property(&jobj, IOTJS_MAGIC_STRING_ONHEADERS);
-  IOTJS_ASSERT(iotjs_jval_is_function(&func));
+  IOTJS_ASSERT(iotjs_jval_is_function(func));
 
   iotjs_jargs_t argv = iotjs_jargs_create(2);
   iotjs_jval_t jheader = iotjs_httpparserwrap_make_header(httpparserwrap);
@@ -240,10 +240,10 @@ static int iotjs_httpparserwrap_on_headers_complete(http_parser* parser) {
   iotjs_httpparserwrap_t* httpparserwrap =
       (iotjs_httpparserwrap_t*)(parser->data);
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, httpparserwrap);
-  const iotjs_jval_t jobj = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  const iotjs_jval_t jobj = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t func =
       iotjs_jval_get_property(&jobj, IOTJS_MAGIC_STRING_ONHEADERSCOMPLETE);
-  IOTJS_ASSERT(iotjs_jval_is_function(&func));
+  IOTJS_ASSERT(iotjs_jval_is_function(func));
 
   // URL
   iotjs_jargs_t argv = iotjs_jargs_create(1);
@@ -297,9 +297,9 @@ static int iotjs_httpparserwrap_on_headers_complete(http_parser* parser) {
   iotjs_jval_t res = iotjs_make_callback_with_result(&func, &jobj, &argv);
 
   int ret = 1;
-  if (iotjs_jval_is_boolean(&res)) {
-    ret = iotjs_jval_as_boolean(&res);
-  } else if (iotjs_jval_is_object(&res)) {
+  if (iotjs_jval_is_boolean(res)) {
+    ret = iotjs_jval_as_boolean(res);
+  } else if (iotjs_jval_is_object(res)) {
     // if exception throw occurs in iotjs_make_callback_with_result, then the
     // result can be an object.
     ret = 0;
@@ -319,9 +319,9 @@ static int iotjs_httpparserwrap_on_body(http_parser* parser, const char* at,
   iotjs_httpparserwrap_t* httpparserwrap =
       (iotjs_httpparserwrap_t*)(parser->data);
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, httpparserwrap);
-  const iotjs_jval_t jobj = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  const iotjs_jval_t jobj = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t func = iotjs_jval_get_property(&jobj, IOTJS_MAGIC_STRING_ONBODY);
-  IOTJS_ASSERT(iotjs_jval_is_function(&func));
+  IOTJS_ASSERT(iotjs_jval_is_function(func));
 
   iotjs_jargs_t argv = iotjs_jargs_create(3);
   iotjs_jargs_append_jval(&argv, &_this->cur_jbuf);
@@ -342,10 +342,10 @@ static int iotjs_httpparserwrap_on_message_complete(http_parser* parser) {
   iotjs_httpparserwrap_t* httpparserwrap =
       (iotjs_httpparserwrap_t*)(parser->data);
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_httpparserwrap_t, httpparserwrap);
-  const iotjs_jval_t jobj = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  const iotjs_jval_t jobj = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t func =
       iotjs_jval_get_property(&jobj, IOTJS_MAGIC_STRING_ONMESSAGECOMPLETE);
-  IOTJS_ASSERT(iotjs_jval_is_function(&func));
+  IOTJS_ASSERT(iotjs_jval_is_function(func));
 
   iotjs_make_callback(&func, &jobj, iotjs_jargs_get_empty());
 
@@ -413,7 +413,7 @@ JHANDLER_FUNCTION(Execute) {
   JHANDLER_DECLARE_THIS_PTR(httpparserwrap, parser);
   DJHANDLER_CHECK_ARGS(1, object);
 
-  iotjs_jval_t jbuffer = *JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t jbuffer = JHANDLER_GET_ARG(0, object);
   iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(jbuffer);
   char* buf_data = iotjs_bufferwrap_buffer(buffer_wrap);
   size_t buf_len = iotjs_bufferwrap_length(buffer_wrap);
@@ -461,7 +461,7 @@ JHANDLER_FUNCTION(HTTPParserCons) {
   DJHANDLER_CHECK_THIS(object);
   DJHANDLER_CHECK_ARGS(1, number);
 
-  const iotjs_jval_t jparser = *JHANDLER_GET_THIS(object);
+  const iotjs_jval_t jparser = JHANDLER_GET_THIS(object);
 
   http_parser_type httpparser_type =
       (http_parser_type)(JHANDLER_GET_ARG(0, number));

--- a/src/modules/iotjs_module_https.c
+++ b/src/modules/iotjs_module_https.c
@@ -31,7 +31,7 @@ iotjs_https_t* iotjs_https_create(const char* URL, const char* method,
                                   const char* ca, const char* cert,
                                   const char* key,
                                   const bool reject_unauthorized,
-                                  iotjs_jval_t jthis) {
+                                  const iotjs_jval_t* jthis) {
   iotjs_https_t* https_data = IOTJS_ALLOC(iotjs_https_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_https_t, https_data);
 
@@ -68,7 +68,7 @@ iotjs_https_t* iotjs_https_create(const char* URL, const char* method,
 
   // Handles
   _this->loop = iotjs_environment_loop(iotjs_environment_get());
-  _this->jthis_native = iotjs_jval_create_copied(&jthis);
+  _this->jthis_native = iotjs_jval_create_copied(jthis);
   iotjs_jval_set_object_native_handle(&(_this->jthis_native),
                                       (uintptr_t)https_data,
                                       &https_native_info);
@@ -182,12 +182,12 @@ void iotjs_https_cleanup(iotjs_https_t* https_data) {
   if (_this->to_destroy_read_onwrite) {
     const iotjs_jargs_t* jarg = iotjs_jargs_get_empty();
     iotjs_jval_t jthis = &(_this->jthis_native);
-    IOTJS_ASSERT(iotjs_jval_is_function(&(_this->read_onwrite)));
+    IOTJS_ASSERT(iotjs_jval_is_function((_this->read_onwrite)));
 
-    if (!iotjs_jval_is_undefined(&(_this->read_callback)))
+    if (!iotjs_jval_is_undefined((_this->read_callback)))
       iotjs_make_callback(&(_this->read_callback), &jthis, jarg);
 
-    iotjs_make_callback(&(_this->read_onwrite), &jthis, jarg);
+    iotjs_make_callback(&(_this->read_onwrite), jthis, jarg);
     _this->to_destroy_read_onwrite = false;
     iotjs_string_destroy(&(_this->read_chunk));
     iotjs_jval_destroy(&(_this->read_onwrite));
@@ -291,7 +291,7 @@ void iotjs_https_initialize_curl_opts(iotjs_https_t* https_data) {
 }
 
 // Get https.ClientRequest from struct
-iotjs_jval_t iotjs_https_jthis_from_https(iotjs_https_t* https_data) {
+iotjs_jval_t* iotjs_https_jthis_from_https(iotjs_https_t* https_data) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
   return &(_this->jthis_native);
 }
@@ -299,22 +299,22 @@ iotjs_jval_t iotjs_https_jthis_from_https(iotjs_https_t* https_data) {
 // Call any property of ClientRequest._Incoming
 bool iotjs_https_jcallback(iotjs_https_t* https_data, const char* property,
                            const iotjs_jargs_t* jarg, bool resultvalue) {
-  iotjs_jval_t jthis = iotjs_https_jthis_from_https(https_data);
+  iotjs_jval_t* jthis = iotjs_https_jthis_from_https(https_data);
   bool retval = true;
-  if (iotjs_jval_is_null(&jthis))
+  if (iotjs_jval_is_null(jthis))
     return retval;
 
   iotjs_jval_t jincoming =
-      iotjs_jval_get_property(&jthis, IOTJS_MAGIC_STRING__INCOMING);
+      iotjs_jval_get_property(jthis, IOTJS_MAGIC_STRING__INCOMING);
   iotjs_jval_t cb = iotjs_jval_get_property(&jincoming, property);
 
-  IOTJS_ASSERT(iotjs_jval_is_function(&cb));
+  IOTJS_ASSERT(iotjs_jval_is_function(cb));
   if (!resultvalue) {
     iotjs_make_callback(&cb, &jincoming, jarg);
   } else {
     iotjs_jval_t result =
         iotjs_make_callback_with_result(&cb, &jincoming, jarg);
-    retval = iotjs_jval_as_boolean(&result);
+    retval = iotjs_jval_as_boolean(result);
     iotjs_jval_destroy(&result);
   }
 
@@ -329,16 +329,16 @@ void iotjs_https_call_read_onwrite(uv_timer_t* timer) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
 
   uv_timer_stop(&(_this->async_read_onwrite));
-  if (iotjs_jval_is_null(&_this->jthis_native))
+  if (iotjs_jval_is_null(_this->jthis_native))
     return;
   const iotjs_jargs_t* jarg = iotjs_jargs_get_empty();
   iotjs_jval_t jthis = _this->jthis_native;
-  IOTJS_ASSERT(iotjs_jval_is_function(&(_this->read_onwrite)));
+  IOTJS_ASSERT(iotjs_jval_is_function((_this->read_onwrite)));
 
-  if (!iotjs_jval_is_undefined(&(_this->read_callback)))
+  if (!iotjs_jval_is_undefined((_this->read_callback)))
     iotjs_make_callback(&(_this->read_callback), &jthis, jarg);
 
-  iotjs_make_callback(&(_this->read_onwrite), &jthis, jarg);
+  iotjs_make_callback(&(_this->read_onwrite), jthis, jarg);
 }
 
 // Call the above method Asynchronously
@@ -365,8 +365,9 @@ void iotjs_https_add_header(iotjs_https_t* https_data,
 
 // Recieved data to write from ClientRequest._write
 void iotjs_https_data_to_write(iotjs_https_t* https_data,
-                               iotjs_string_t read_chunk, iotjs_jval_t callback,
-                               iotjs_jval_t onwrite) {
+                               iotjs_string_t read_chunk,
+                               const iotjs_jval_t* callback,
+                               const iotjs_jval_t* onwrite) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
 
   if (_this->to_destroy_read_onwrite) {
@@ -379,8 +380,8 @@ void iotjs_https_data_to_write(iotjs_https_t* https_data,
   _this->read_chunk = read_chunk;
   _this->data_to_read = true;
 
-  _this->read_callback = iotjs_jval_create_copied(&callback);
-  _this->read_onwrite = iotjs_jval_create_copied(&onwrite);
+  _this->read_callback = iotjs_jval_create_copied(callback);
+  _this->read_onwrite = iotjs_jval_create_copied(onwrite);
   _this->to_destroy_read_onwrite = true;
 
   if (_this->request_done) {
@@ -553,7 +554,7 @@ size_t iotjs_https_curl_write_callback(void* contents, size_t size,
   iotjs_https_t* https_data = (iotjs_https_t*)userp;
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_https_t, https_data);
   size_t real_size = size * nmemb;
-  if (iotjs_jval_is_null(&_this->jthis_native))
+  if (iotjs_jval_is_null(_this->jthis_native))
     return real_size - 1;
   iotjs_jargs_t jarg = iotjs_jargs_create(1);
   iotjs_jval_t jresult_arr = iotjs_jval_create_byte_array(real_size, contents);
@@ -718,32 +719,32 @@ JHANDLER_FUNCTION(createRequest) {
   DJHANDLER_CHECK_THIS(object);
   DJHANDLER_CHECK_ARGS(1, object);
 
-  const iotjs_jval_t jthis = *JHANDLER_GET_ARG(0, object);
+  const iotjs_jval_t jthis = JHANDLER_GET_ARG(0, object);
 
   iotjs_jval_t jhost = iotjs_jval_get_property(&jthis, IOTJS_MAGIC_STRING_HOST);
-  iotjs_string_t host = iotjs_jval_as_string(&jhost);
+  iotjs_string_t host = iotjs_jval_as_string(jhost);
   iotjs_jval_destroy(&jhost);
 
   iotjs_jval_t jmethod =
       iotjs_jval_get_property(&jthis, IOTJS_MAGIC_STRING_METHOD);
-  iotjs_string_t method = iotjs_jval_as_string(&jmethod);
+  iotjs_string_t method = iotjs_jval_as_string(jmethod);
   iotjs_jval_destroy(&jmethod);
 
   iotjs_jval_t jca = iotjs_jval_get_property(&jthis, IOTJS_MAGIC_STRING_CA);
-  iotjs_string_t ca = iotjs_jval_as_string(&jca);
+  iotjs_string_t ca = iotjs_jval_as_string(jca);
   iotjs_jval_destroy(&jca);
 
   iotjs_jval_t jcert = iotjs_jval_get_property(&jthis, IOTJS_MAGIC_STRING_CERT);
-  iotjs_string_t cert = iotjs_jval_as_string(&jcert);
+  iotjs_string_t cert = iotjs_jval_as_string(jcert);
   iotjs_jval_destroy(&jcert);
 
   iotjs_jval_t jkey = iotjs_jval_get_property(&jthis, IOTJS_MAGIC_STRING_KEY);
-  iotjs_string_t key = iotjs_jval_as_string(&jkey);
+  iotjs_string_t key = iotjs_jval_as_string(jkey);
   iotjs_jval_destroy(&jkey);
 
   iotjs_jval_t jreject_unauthorized =
       iotjs_jval_get_property(&jthis, IOTJS_MAGIC_STRING_REJECTUNAUTHORIZED);
-  const bool reject_unauthorized = iotjs_jval_as_boolean(&jreject_unauthorized);
+  const bool reject_unauthorized = iotjs_jval_as_boolean(jreject_unauthorized);
 
   if (curl_global_init(CURL_GLOBAL_SSL)) {
     return;
@@ -751,7 +752,7 @@ JHANDLER_FUNCTION(createRequest) {
   iotjs_https_t* https_data =
       iotjs_https_create(iotjs_string_data(&host), iotjs_string_data(&method),
                          iotjs_string_data(&ca), iotjs_string_data(&cert),
-                         iotjs_string_data(&key), reject_unauthorized, &jthis);
+                         iotjs_string_data(&key), reject_unauthorized, jthis);
 
   iotjs_https_initialize_curl_opts(https_data);
 
@@ -770,9 +771,9 @@ JHANDLER_FUNCTION(addHeader) {
   iotjs_string_t header = JHANDLER_GET_ARG(0, string);
   const char* char_header = iotjs_string_data(&header);
 
-  iotjs_jval_t jthis = *JHANDLER_GET_ARG(1, object);
+  iotjs_jval_t jthis = JHANDLER_GET_ARG(1, object);
   iotjs_https_t* https_data =
-      (iotjs_https_t*)iotjs_jval_get_object_native_handle(&jthis);
+      (iotjs_https_t*)iotjs_jval_get_object_native_handle(jthis);
   iotjs_https_add_header(https_data, char_header);
 
   iotjs_string_destroy(&header);
@@ -783,9 +784,9 @@ JHANDLER_FUNCTION(sendRequest) {
   DJHANDLER_CHECK_THIS(object);
 
   DJHANDLER_CHECK_ARG(0, object);
-  iotjs_jval_t jthis = *JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t jthis = JHANDLER_GET_ARG(0, object);
   iotjs_https_t* https_data =
-      (iotjs_https_t*)iotjs_jval_get_object_native_handle(&jthis);
+      (iotjs_https_t*)iotjs_jval_get_object_native_handle(jthis);
   iotjs_https_send_request(https_data);
   iotjs_jhandler_return_null(jhandler);
 }
@@ -795,10 +796,10 @@ JHANDLER_FUNCTION(setTimeout) {
   DJHANDLER_CHECK_ARGS(2, number, object);
 
   double ms = JHANDLER_GET_ARG(0, number);
-  iotjs_jval_t jthis = *JHANDLER_GET_ARG(1, object);
+  iotjs_jval_t jthis = JHANDLER_GET_ARG(1, object);
 
   iotjs_https_t* https_data =
-      (iotjs_https_t*)iotjs_jval_get_object_native_handle(&jthis);
+      (iotjs_https_t*)iotjs_jval_get_object_native_handle(jthis);
   iotjs_https_set_timeout((long)ms, https_data);
 
   iotjs_jhandler_return_null(jhandler);
@@ -810,14 +811,14 @@ JHANDLER_FUNCTION(_write) {
   // Argument 3 can be null, so not checked directly, checked later
   DJHANDLER_CHECK_ARG(3, function);
 
-  iotjs_jval_t jthis = *JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t jthis = JHANDLER_GET_ARG(0, object);
   iotjs_string_t read_chunk = JHANDLER_GET_ARG(1, string);
 
-  iotjs_jval_t callback = *iotjs_jhandler_get_arg(jhandler, 2);
-  iotjs_jval_t onwrite = *JHANDLER_GET_ARG(3, function);
+  iotjs_jval_t callback = iotjs_jhandler_get_arg(jhandler, 2);
+  iotjs_jval_t onwrite = JHANDLER_GET_ARG(3, function);
 
   iotjs_https_t* https_data =
-      (iotjs_https_t*)iotjs_jval_get_object_native_handle(&jthis);
+      (iotjs_https_t*)iotjs_jval_get_object_native_handle(jthis);
   iotjs_https_data_to_write(https_data, read_chunk, callback, onwrite);
 
   // readchunk was copied to https_data, hence not destroyed.
@@ -828,9 +829,9 @@ JHANDLER_FUNCTION(finishRequest) {
   DJHANDLER_CHECK_THIS(object);
   DJHANDLER_CHECK_ARG(0, object);
 
-  iotjs_jval_t jthis = *JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t jthis = JHANDLER_GET_ARG(0, object);
   iotjs_https_t* https_data =
-      (iotjs_https_t*)iotjs_jval_get_object_native_handle(&jthis);
+      (iotjs_https_t*)iotjs_jval_get_object_native_handle(jthis);
   iotjs_https_finish_request(https_data);
 
   iotjs_jhandler_return_null(jhandler);
@@ -840,9 +841,9 @@ JHANDLER_FUNCTION(Abort) {
   DJHANDLER_CHECK_THIS(object);
   DJHANDLER_CHECK_ARG(0, object);
 
-  iotjs_jval_t jthis = *JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t jthis = JHANDLER_GET_ARG(0, object);
   iotjs_https_t* https_data =
-      (iotjs_https_t*)iotjs_jval_get_object_native_handle(&jthis);
+      (iotjs_https_t*)iotjs_jval_get_object_native_handle(jthis);
   iotjs_https_cleanup(https_data);
 
   iotjs_jhandler_return_null(jhandler);

--- a/src/modules/iotjs_module_https.h
+++ b/src/modules/iotjs_module_https.h
@@ -89,7 +89,7 @@ iotjs_https_t* iotjs_https_create(const char* URL, const char* method,
                                   const char* ca, const char* cert,
                                   const char* key,
                                   const bool reject_unauthorized,
-                                  iotjs_jval_t jthis);
+                                  const iotjs_jval_t* jthis);
 
 #define THIS iotjs_https_t* https_data
 // Some utility functions
@@ -97,7 +97,7 @@ void iotjs_https_check_done(THIS);
 void iotjs_https_cleanup(THIS);
 CURLM* iotjs_https_get_multi_handle(THIS);
 void iotjs_https_initialize_curl_opts(THIS);
-iotjs_jval_t iotjs_https_jthis_from_https(THIS);
+iotjs_jval_t* iotjs_https_jthis_from_https(THIS);
 bool iotjs_https_jcallback(THIS, const char* property,
                            const iotjs_jargs_t* jarg, bool resultvalue);
 void iotjs_https_call_read_onwrite(uv_timer_t* timer);
@@ -106,7 +106,8 @@ void iotjs_https_call_read_onwrite_async(THIS);
 // Functions almost directly called by JS via JHANDLER
 void iotjs_https_add_header(THIS, const char* char_header);
 void iotjs_https_data_to_write(THIS, iotjs_string_t read_chunk,
-                               iotjs_jval_t callback, iotjs_jval_t onwrite);
+                               const iotjs_jval_t* callback,
+                               const iotjs_jval_t* onwrite);
 void iotjs_https_finish_request(THIS);
 void iotjs_https_send_request(THIS);
 void iotjs_https_set_timeout(long ms, THIS);

--- a/src/modules/iotjs_module_i2c.c
+++ b/src/modules/iotjs_module_i2c.c
@@ -29,7 +29,7 @@ static void i2c_destroy_data(iotjs_i2c_t* i2c) {
 }
 
 static iotjs_i2c_t* iotjs_i2c_create(iotjs_jhandler_t* jhandler,
-                                     const iotjs_jval_t ji2c) {
+                                     iotjs_jval_t ji2c) {
   iotjs_i2c_t* i2c = IOTJS_ALLOC(iotjs_i2c_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_i2c_t, i2c);
   i2c_create_platform_data(jhandler, i2c, &_this->platform_data);
@@ -39,7 +39,7 @@ static iotjs_i2c_t* iotjs_i2c_create(iotjs_jhandler_t* jhandler,
 }
 
 static iotjs_i2c_reqwrap_t* iotjs_i2c_reqwrap_create(
-    const iotjs_jval_t jcallback, iotjs_i2c_t* i2c, I2cOp op) {
+    iotjs_jval_t jcallback, iotjs_i2c_t* i2c, I2cOp op) {
   iotjs_i2c_reqwrap_t* i2c_reqwrap = IOTJS_ALLOC(iotjs_i2c_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_i2c_reqwrap_t, i2c_reqwrap);
 
@@ -66,9 +66,9 @@ uv_work_t* iotjs_i2c_reqwrap_req(THIS) {
   return &_this->req;
 }
 
-iotjs_jval_t iotjs_i2c_reqwrap_jcallback(THIS) {
+const iotjs_jval_t* iotjs_i2c_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_i2c_reqwrap_t, i2c_reqwrap);
-  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 iotjs_i2c_reqwrap_t* iotjs_i2c_reqwrap_from_request(uv_work_t* req) {
@@ -93,8 +93,8 @@ static void iotjs_i2c_destroy(iotjs_i2c_t* i2c) {
   IOTJS_RELEASE(i2c);
 }
 
-iotjs_i2c_t* iotjs_i2c_instance_from_jval(const iotjs_jval_t ji2c) {
-  iotjs_jobjectwrap_t* jobjectwrap = iotjs_jobjectwrap_from_jobject(&ji2c);
+iotjs_i2c_t* iotjs_i2c_instance_from_jval(const iotjs_jval_t* ji2c) {
+  iotjs_jobjectwrap_t* jobjectwrap = iotjs_jobjectwrap_from_jobject(ji2c);
   return (iotjs_i2c_t*)jobjectwrap;
 }
 
@@ -164,27 +164,27 @@ void AfterI2CWork(uv_work_t* work_req, int status) {
     }
   }
 
-  const iotjs_jval_t jcallback = iotjs_i2c_reqwrap_jcallback(req_wrap);
-  iotjs_make_callback(&jcallback, iotjs_jval_get_undefined(), &jargs);
+  const iotjs_jval_t* jcallback = iotjs_i2c_reqwrap_jcallback(req_wrap);
+  iotjs_make_callback(jcallback, iotjs_jval_get_undefined(), &jargs);
 
   iotjs_jargs_destroy(&jargs);
   iotjs_i2c_reqwrap_dispatched(req_wrap);
 }
 
-static void GetI2cArray(const iotjs_jval_t jarray,
+static void GetI2cArray(iotjs_jval_t jarray,
                         iotjs_i2c_reqdata_t* req_data) {
   // FIXME
   // Need to implement a function to get array info from iotjs_jval_t Array.
   iotjs_jval_t jlength =
       iotjs_jval_get_property(&jarray, IOTJS_MAGIC_STRING_LENGTH);
-  IOTJS_ASSERT(!iotjs_jval_is_undefined(&jlength));
+  IOTJS_ASSERT(!iotjs_jval_is_undefined(jlength));
 
-  req_data->buf_len = iotjs_jval_as_number(&jlength);
+  req_data->buf_len = iotjs_jval_as_number(jlength);
   req_data->buf_data = iotjs_buffer_allocate(req_data->buf_len);
 
   for (uint8_t i = 0; i < req_data->buf_len; i++) {
     iotjs_jval_t jdata = iotjs_jval_get_property_by_index(&jarray, i);
-    req_data->buf_data[i] = iotjs_jval_as_number(&jdata);
+    req_data->buf_data[i] = iotjs_jval_as_number(jdata);
     iotjs_jval_destroy(&jdata);
   }
 
@@ -201,13 +201,13 @@ static void GetI2cArray(const iotjs_jval_t jarray,
 JHANDLER_FUNCTION(I2cCons) {
   DJHANDLER_CHECK_THIS(object);
   // Create I2C object
-  const iotjs_jval_t ji2c = *JHANDLER_GET_THIS(object);
+  const iotjs_jval_t ji2c = JHANDLER_GET_THIS(object);
   iotjs_i2c_t* i2c = iotjs_i2c_create(jhandler, ji2c);
   IOTJS_ASSERT(i2c ==
-               (iotjs_i2c_t*)(iotjs_jval_get_object_native_handle(&ji2c)));
+               (iotjs_i2c_t*)(iotjs_jval_get_object_native_handle(ji2c)));
 
   // Create I2C request wrap
-  const iotjs_jval_t jcallback = *JHANDLER_GET_ARG(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG(1, function);
   iotjs_i2c_reqwrap_t* req_wrap =
       iotjs_i2c_reqwrap_create(jcallback, i2c, kI2cOpOpen);
 
@@ -237,13 +237,13 @@ JHANDLER_FUNCTION(Write) {
   JHANDLER_DECLARE_THIS_PTR(i2c, i2c);
   DJHANDLER_CHECK_ARGS(2, array, function);
 
-  const iotjs_jval_t jcallback = *JHANDLER_GET_ARG(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG(1, function);
 
   iotjs_i2c_reqwrap_t* req_wrap =
       iotjs_i2c_reqwrap_create(jcallback, i2c, kI2cOpWrite);
   iotjs_i2c_reqdata_t* req_data = iotjs_i2c_reqwrap_data(req_wrap);
 
-  GetI2cArray(*JHANDLER_GET_ARG(0, array), req_data);
+  GetI2cArray(JHANDLER_GET_ARG(0, array), req_data);
 
   I2C_ASYNC(Write);
 
@@ -254,7 +254,7 @@ JHANDLER_FUNCTION(Read) {
   JHANDLER_DECLARE_THIS_PTR(i2c, i2c);
   DJHANDLER_CHECK_ARGS(2, number, function);
 
-  const iotjs_jval_t jcallback = *JHANDLER_GET_ARG(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG(1, function);
 
   iotjs_i2c_reqwrap_t* req_wrap =
       iotjs_i2c_reqwrap_create(jcallback, i2c, kI2cOpRead);

--- a/src/modules/iotjs_module_i2c.h
+++ b/src/modules/iotjs_module_i2c.h
@@ -64,12 +64,12 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_i2c_reqwrap_t);
 
 
-iotjs_i2c_t* iotjs_i2c_instance_from_jval(const iotjs_jval_t ji2c);
+iotjs_i2c_t* iotjs_i2c_instance_from_jval(const iotjs_jval_t* ji2c);
 iotjs_i2c_reqwrap_t* iotjs_i2c_reqwrap_from_request(uv_work_t* req);
 #define THIS iotjs_i2c_reqwrap_t* i2c_reqwrap
 void iotjs_i2c_reqwrap_dispatched(THIS);
 uv_work_t* iotjs_i2c_reqwrap_req(THIS);
-iotjs_jval_t iotjs_i2c_reqwrap_jcallback(THIS);
+const iotjs_jval_t* iotjs_i2c_reqwrap_jcallback(THIS);
 iotjs_i2c_reqdata_t* iotjs_i2c_reqwrap_data(THIS);
 iotjs_i2c_t* iotjs_i2c_instance_from_reqwrap(THIS);
 #undef THIS

--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -25,10 +25,10 @@ JHANDLER_FUNCTION(Binding) {
 
   ModuleKind module_kind = (ModuleKind)JHANDLER_GET_ARG(0, number);
 
-  const iotjs_jval_t jmodule =
-      *iotjs_module_initialize_if_necessary(module_kind);
+  const iotjs_jval_t* jmodule =
+      iotjs_module_initialize_if_necessary(module_kind);
 
-  iotjs_jhandler_return_jval(jhandler, &jmodule);
+  iotjs_jhandler_return_jval(jhandler, jmodule);
 }
 
 
@@ -181,15 +181,15 @@ JHANDLER_FUNCTION(DoExit) {
 }
 
 
-void SetNativeSources(iotjs_jval_t native_sources) {
+void SetNativeSources(iotjs_jval_t* native_sources) {
   for (int i = 0; natives[i].name; i++) {
-    iotjs_jval_set_property_jval(&native_sources, natives[i].name,
+    iotjs_jval_set_property_jval(native_sources, natives[i].name,
                                  iotjs_jval_get_boolean(true));
   }
 }
 
 
-static void SetProcessEnv(iotjs_jval_t process) {
+static void SetProcessEnv(iotjs_jval_t* process) {
   const char *homedir, *iotjspath, *iotjsenv;
 
   homedir = getenv("HOME");
@@ -219,16 +219,16 @@ static void SetProcessEnv(iotjs_jval_t process) {
   iotjs_jval_set_property_string_raw(&env, IOTJS_MAGIC_STRING_IOTJS_ENV,
                                      iotjsenv);
 
-  iotjs_jval_set_property_jval(&process, IOTJS_MAGIC_STRING_ENV, &env);
+  iotjs_jval_set_property_jval(process, IOTJS_MAGIC_STRING_ENV, &env);
 
   iotjs_jval_destroy(&env);
 }
 
 
-static void SetProcessIotjs(iotjs_jval_t process) {
+static void SetProcessIotjs(iotjs_jval_t* process) {
   // IoT.js specific
   iotjs_jval_t iotjs = iotjs_jval_create_object();
-  iotjs_jval_set_property_jval(&process, IOTJS_MAGIC_STRING_IOTJS, &iotjs);
+  iotjs_jval_set_property_jval(process, IOTJS_MAGIC_STRING_IOTJS, &iotjs);
 
   iotjs_jval_set_property_string_raw(&iotjs, IOTJS_MAGIC_STRING_BOARD,
                                      TOSTRING(TARGET_BOARD));
@@ -236,7 +236,7 @@ static void SetProcessIotjs(iotjs_jval_t process) {
 }
 
 
-static void SetProcessArgv(iotjs_jval_t process) {
+static void SetProcessArgv(iotjs_jval_t* process) {
   const iotjs_environment_t* env = iotjs_environment_get();
   uint32_t argc = iotjs_environment_argc(env);
 
@@ -248,7 +248,7 @@ static void SetProcessArgv(iotjs_jval_t process) {
     iotjs_jval_set_property_by_index(&argv, i, &arg);
     iotjs_jval_destroy(&arg);
   }
-  iotjs_jval_set_property_jval(&process, IOTJS_MAGIC_STRING_ARGV, &argv);
+  iotjs_jval_set_property_jval(process, IOTJS_MAGIC_STRING_ARGV, &argv);
 
   iotjs_jval_destroy(&argv);
 }
@@ -265,11 +265,11 @@ iotjs_jval_t InitProcess() {
   iotjs_jval_set_method(&process, IOTJS_MAGIC_STRING_CWD, Cwd);
   iotjs_jval_set_method(&process, IOTJS_MAGIC_STRING_CHDIR, Chdir);
   iotjs_jval_set_method(&process, IOTJS_MAGIC_STRING_DOEXIT, DoExit);
-  SetProcessEnv(process);
+  SetProcessEnv(&process);
 
   // process.native_sources
   iotjs_jval_t native_sources = iotjs_jval_create_object();
-  SetNativeSources(native_sources);
+  SetNativeSources(&native_sources);
   iotjs_jval_set_property_jval(&process, IOTJS_MAGIC_STRING_NATIVE_SOURCES,
                                &native_sources);
   iotjs_jval_destroy(&native_sources);
@@ -287,9 +287,9 @@ iotjs_jval_t InitProcess() {
                                      IOTJS_VERSION);
 
   // Set iotjs
-  SetProcessIotjs(process);
+  SetProcessIotjs(&process);
 
-  SetProcessArgv(process);
+  SetProcessArgv(&process);
 
   // Binding module id.
   iotjs_jval_t jbinding =

--- a/src/modules/iotjs_module_pwm.c
+++ b/src/modules/iotjs_module_pwm.c
@@ -22,10 +22,10 @@ static iotjs_pwm_t* iotjs_pwm_instance_from_jval(iotjs_jval_t jpwm);
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(pwm);
 
 
-static iotjs_pwm_t* iotjs_pwm_create(iotjs_jval_t jpwm) {
+static iotjs_pwm_t* iotjs_pwm_create(const iotjs_jval_t* jpwm) {
   iotjs_pwm_t* pwm = IOTJS_ALLOC(iotjs_pwm_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_pwm_t, pwm);
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, &jpwm,
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jpwm,
                                &this_module_native_info);
 
   _this->period = -1;
@@ -50,13 +50,12 @@ static void iotjs_pwm_destroy(iotjs_pwm_t* pwm) {
 #define THIS iotjs_pwm_reqwrap_t* pwm_reqwrap
 
 
-static iotjs_pwm_reqwrap_t* iotjs_pwm_reqwrap_create(iotjs_jval_t jcallback,
-                                                     iotjs_pwm_t* pwm,
-                                                     PwmOp op) {
+static iotjs_pwm_reqwrap_t* iotjs_pwm_reqwrap_create(
+    const iotjs_jval_t* jcallback, iotjs_pwm_t* pwm, PwmOp op) {
   iotjs_pwm_reqwrap_t* pwm_reqwrap = IOTJS_ALLOC(iotjs_pwm_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_pwm_reqwrap_t, pwm_reqwrap);
 
-  iotjs_reqwrap_initialize(&_this->reqwrap, &jcallback, (uv_req_t*)&_this->req);
+  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
 
   _this->req_data.op = op;
   _this->pwm_instance = pwm;
@@ -85,14 +84,14 @@ static uv_work_t* iotjs_pwm_reqwrap_req(THIS) {
 }
 
 
-static iotjs_jval_t iotjs_pwm_reqwrap_jcallback(THIS) {
+static const iotjs_jval_t* iotjs_pwm_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_pwm_reqwrap_t, pwm_reqwrap);
-  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 
 static iotjs_pwm_t* iotjs_pwm_instance_from_jval(iotjs_jval_t jpwm) {
-  uintptr_t handle = iotjs_jval_get_object_native_handle(&jpwm);
+  uintptr_t handle = iotjs_jval_get_object_native_handle(jpwm);
   return (iotjs_pwm_t*)handle;
 }
 
@@ -120,24 +119,24 @@ static void iotjs_pwm_set_configuration(iotjs_jval_t jconfiguration,
 
   iotjs_jval_t jpin =
       iotjs_jval_get_property(&jconfiguration, IOTJS_MAGIC_STRING_PIN);
-  _this->pin = iotjs_jval_as_number(&jpin);
+  _this->pin = iotjs_jval_as_number(jpin);
 
 #if defined(__linux__)
   iotjs_jval_t jchip =
       iotjs_jval_get_property(&jconfiguration, IOTJS_MAGIC_STRING_CHIP);
-  _this->chip = iotjs_jval_as_number(&jchip);
+  _this->chip = iotjs_jval_as_number(jchip);
   iotjs_jval_destroy(&jchip);
 #endif
 
   iotjs_jval_t jperiod =
       iotjs_jval_get_property(&jconfiguration, IOTJS_MAGIC_STRING_PERIOD);
-  if (iotjs_jval_is_number(&jperiod))
-    _this->period = iotjs_jval_as_number(&jperiod);
+  if (iotjs_jval_is_number(jperiod))
+    _this->period = iotjs_jval_as_number(jperiod);
 
   iotjs_jval_t jduty_cycle =
       iotjs_jval_get_property(&jconfiguration, IOTJS_MAGIC_STRING_DUTYCYCLE);
-  if (iotjs_jval_is_number(&jduty_cycle))
-    _this->duty_cycle = iotjs_jval_as_number(&jduty_cycle);
+  if (iotjs_jval_is_number(jduty_cycle))
+    _this->duty_cycle = iotjs_jval_as_number(jduty_cycle);
 
   iotjs_jval_destroy(&jpin);
   iotjs_jval_destroy(&jperiod);
@@ -215,8 +214,8 @@ static void iotjs_pwm_after_worker(uv_work_t* work_req, int status) {
     }
   }
 
-  iotjs_jval_t jcallback = iotjs_pwm_reqwrap_jcallback(req_wrap);
-  iotjs_make_callback(&jcallback, iotjs_jval_get_undefined(), &jargs);
+  const iotjs_jval_t* jcallback = iotjs_pwm_reqwrap_jcallback(req_wrap);
+  iotjs_make_callback(jcallback, iotjs_jval_get_undefined(), &jargs);
 
   iotjs_jargs_destroy(&jargs);
 
@@ -252,17 +251,17 @@ JHANDLER_FUNCTION(PWMConstructor) {
   DJHANDLER_CHECK_ARGS(2, object, function);
 
   // Create PWM object
-  iotjs_jval_t jpwm = *JHANDLER_GET_THIS(object);
-  iotjs_pwm_t* pwm = iotjs_pwm_create(jpwm);
+  iotjs_jval_t jpwm = JHANDLER_GET_THIS(object);
+  iotjs_pwm_t* pwm = iotjs_pwm_create(&jpwm);
   IOTJS_ASSERT(pwm == iotjs_pwm_instance_from_jval(jpwm));
 
-  iotjs_jval_t jconfiguration = *JHANDLER_GET_ARG(0, object);
-  iotjs_jval_t jcallback = *JHANDLER_GET_ARG(1, function);
+  iotjs_jval_t jconfiguration = JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t jcallback = JHANDLER_GET_ARG(1, function);
 
   // Set configuration
   iotjs_pwm_set_configuration(jconfiguration, pwm);
 
-  PWM_ASYNC(open, pwm, jcallback, kPwmOpOpen);
+  PWM_ASYNC(open, pwm, &jcallback, kPwmOpOpen);
 }
 
 
@@ -272,13 +271,13 @@ JHANDLER_FUNCTION(SetPeriod) {
   DJHANDLER_CHECK_ARGS(1, number);
   DJHANDLER_CHECK_ARG_IF_EXIST(1, function);
 
-  iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
 
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_pwm_t, pwm);
   _this->period = JHANDLER_GET_ARG(0, number);
 
   if (!jerry_value_is_null(jcallback)) {
-    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_period, pwm, jcallback,
+    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_period, pwm, &jcallback,
                             kPwmOpSetPeriod);
   } else {
     if (!iotjs_pwm_set_period(pwm)) {
@@ -296,13 +295,13 @@ JHANDLER_FUNCTION(SetDutyCycle) {
   DJHANDLER_CHECK_ARGS(1, number);
   DJHANDLER_CHECK_ARG_IF_EXIST(1, function);
 
-  iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
 
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_pwm_t, pwm);
   _this->duty_cycle = JHANDLER_GET_ARG(0, number);
 
   if (!jerry_value_is_null(jcallback)) {
-    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_dutycycle, pwm, jcallback,
+    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_dutycycle, pwm, &jcallback,
                             kPwmOpSetDutyCycle);
   } else {
     if (!iotjs_pwm_set_dutycycle(pwm)) {
@@ -320,13 +319,13 @@ JHANDLER_FUNCTION(SetEnable) {
   DJHANDLER_CHECK_ARGS(1, boolean);
   DJHANDLER_CHECK_ARG_IF_EXIST(1, function);
 
-  iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(1, function);
 
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_pwm_t, pwm);
   _this->enable = JHANDLER_GET_ARG(0, boolean);
 
   if (!jerry_value_is_null(jcallback)) {
-    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_enable, pwm, jcallback,
+    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_enable, pwm, &jcallback,
                             kPwmOpSetEnable);
   } else {
     if (!iotjs_pwm_set_enable(pwm)) {
@@ -342,10 +341,10 @@ JHANDLER_FUNCTION(Close) {
   JHANDLER_DECLARE_THIS_PTR(pwm, pwm);
   DJHANDLER_CHECK_ARG_IF_EXIST(0, function);
 
-  iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
 
   if (!jerry_value_is_null(jcallback)) {
-    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_close, pwm, jcallback, kPwmOpClose);
+    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_close, pwm, &jcallback, kPwmOpClose);
   } else {
     if (!iotjs_pwm_close(pwm)) {
       JHANDLER_THROW(COMMON, "PWM Close Error");

--- a/src/modules/iotjs_module_spi.c
+++ b/src/modules/iotjs_module_spi.c
@@ -85,9 +85,9 @@ static uv_work_t* iotjs_spi_reqwrap_req(THIS) {
 }
 
 
-static iotjs_jval_t iotjs_spi_reqwrap_jcallback(THIS) {
+static const iotjs_jval_t* iotjs_spi_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_spi_reqwrap_t, spi_reqwrap);
-  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 
@@ -114,15 +114,15 @@ iotjs_spi_t* iotjs_spi_instance_from_reqwrap(THIS) {
 static int iotjs_spi_get_array_data(char** buf, iotjs_jval_t jarray) {
   iotjs_jval_t jlength =
       iotjs_jval_get_property(&jarray, IOTJS_MAGIC_STRING_LENGTH);
-  IOTJS_ASSERT(!iotjs_jval_is_undefined(&jlength));
+  IOTJS_ASSERT(!iotjs_jval_is_undefined(jlength));
 
-  size_t length = iotjs_jval_as_number(&jlength);
+  size_t length = iotjs_jval_as_number(jlength);
   IOTJS_ASSERT((int)length >= 0);
   *buf = iotjs_buffer_allocate(length);
 
   for (size_t i = 0; i < length; i++) {
     iotjs_jval_t jdata = iotjs_jval_get_property_by_index(&jarray, i);
-    (*buf)[i] = iotjs_jval_as_number(&jdata);
+    (*buf)[i] = iotjs_jval_as_number(jdata);
     iotjs_jval_destroy(&jdata);
   }
 
@@ -180,42 +180,42 @@ static void iotjs_spi_set_configuration(iotjs_spi_t* spi,
 #if defined(__linux__)
   iotjs_jval_t jdevice =
       iotjs_jval_get_property(&joptions, IOTJS_MAGIC_STRING_DEVICE);
-  _this->device = iotjs_jval_as_string(&jdevice);
+  _this->device = iotjs_jval_as_string(jdevice);
   iotjs_jval_destroy(&jdevice);
 #elif defined(__NUTTX__) || defined(__TIZENRT__)
   iotjs_jval_t jbus =
       iotjs_jval_get_property(&joptions, IOTJS_MAGIC_STRING_BUS);
-  _this->bus = iotjs_jval_as_number(&jbus);
+  _this->bus = iotjs_jval_as_number(jbus);
   iotjs_jval_destroy(&jbus);
 #endif
   iotjs_jval_t jmode =
       iotjs_jval_get_property(&joptions, IOTJS_MAGIC_STRING_MODE);
-  _this->mode = (SpiMode)iotjs_jval_as_number(&jmode);
+  _this->mode = (SpiMode)iotjs_jval_as_number(jmode);
   iotjs_jval_destroy(&jmode);
 
   iotjs_jval_t jchip_select =
       iotjs_jval_get_property(&joptions, IOTJS_MAGIC_STRING_CHIPSELECT);
-  _this->chip_select = (SpiChipSelect)iotjs_jval_as_number(&jchip_select);
+  _this->chip_select = (SpiChipSelect)iotjs_jval_as_number(jchip_select);
   iotjs_jval_destroy(&jchip_select);
 
   iotjs_jval_t jmax_speed =
       iotjs_jval_get_property(&joptions, IOTJS_MAGIC_STRING_MAXSPEED);
-  _this->max_speed = iotjs_jval_as_number(&jmax_speed);
+  _this->max_speed = iotjs_jval_as_number(jmax_speed);
   iotjs_jval_destroy(&jmax_speed);
 
   iotjs_jval_t jbits_per_word =
       iotjs_jval_get_property(&joptions, IOTJS_MAGIC_STRING_BITSPERWORD);
-  _this->bits_per_word = (SpiOrder)iotjs_jval_as_number(&jbits_per_word);
+  _this->bits_per_word = (SpiOrder)iotjs_jval_as_number(jbits_per_word);
   iotjs_jval_destroy(&jbits_per_word);
 
   iotjs_jval_t jbit_order =
       iotjs_jval_get_property(&joptions, IOTJS_MAGIC_STRING_BITORDER);
-  _this->bit_order = (SpiOrder)iotjs_jval_as_number(&jbit_order);
+  _this->bit_order = (SpiOrder)iotjs_jval_as_number(jbit_order);
   iotjs_jval_destroy(&jbit_order);
 
   iotjs_jval_t jloopback =
       iotjs_jval_get_property(&joptions, IOTJS_MAGIC_STRING_LOOPBACK);
-  _this->loopback = iotjs_jval_as_boolean(&jloopback);
+  _this->loopback = iotjs_jval_as_boolean(jloopback);
   iotjs_jval_destroy(&jloopback);
 }
 
@@ -301,8 +301,8 @@ static void iotjs_spi_after_work(uv_work_t* work_req, int status) {
     }
   }
 
-  iotjs_jval_t jcallback = iotjs_spi_reqwrap_jcallback(req_wrap);
-  iotjs_make_callback(&jcallback, iotjs_jval_get_undefined(), &jargs);
+  const iotjs_jval_t* jcallback = iotjs_spi_reqwrap_jcallback(req_wrap);
+  iotjs_make_callback(jcallback, iotjs_jval_get_undefined(), &jargs);
 
   iotjs_jargs_destroy(&jargs);
 
@@ -311,7 +311,7 @@ static void iotjs_spi_after_work(uv_work_t* work_req, int status) {
 
 
 iotjs_spi_t* iotjs_spi_get_instance(iotjs_jval_t jspi) {
-  uintptr_t handle = iotjs_jval_get_object_native_handle(&jspi);
+  uintptr_t handle = iotjs_jval_get_object_native_handle(jspi);
   return (iotjs_spi_t*)(handle);
 }
 
@@ -331,15 +331,15 @@ JHANDLER_FUNCTION(SpiConstructor) {
   DJHANDLER_CHECK_ARGS(2, object, function);
 
   // Create SPI object
-  iotjs_jval_t jspi = *JHANDLER_GET_THIS(object);
+  iotjs_jval_t jspi = JHANDLER_GET_THIS(object);
   iotjs_spi_t* spi = iotjs_spi_create(jspi);
   IOTJS_ASSERT(spi == iotjs_spi_get_instance(jspi));
 
   // Set configuration
-  iotjs_jval_t jconfiguration = *JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t jconfiguration = JHANDLER_GET_ARG(0, object);
   iotjs_spi_set_configuration(spi, jconfiguration);
 
-  iotjs_jval_t jcallback = *JHANDLER_GET_ARG(1, function);
+  iotjs_jval_t jcallback = JHANDLER_GET_ARG(1, function);
   SPI_ASYNC(open, spi, jcallback, kSpiOpOpen);
 }
 
@@ -351,10 +351,10 @@ JHANDLER_FUNCTION(TransferArray) {
   DJHANDLER_CHECK_ARGS(2, array, array);
   DJHANDLER_CHECK_ARG_IF_EXIST(2, function);
 
-  iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(2, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(2, function);
 
-  iotjs_spi_set_array_buffer(spi, *JHANDLER_GET_ARG(0, array),
-                             *JHANDLER_GET_ARG(1, array));
+  iotjs_spi_set_array_buffer(spi, JHANDLER_GET_ARG(0, array),
+                             JHANDLER_GET_ARG(1, array));
 
   if (!jerry_value_is_null(jcallback)) {
     SPI_ASYNC(transfer, spi, jcallback, kSpiOpTransferArray);
@@ -381,10 +381,10 @@ JHANDLER_FUNCTION(TransferBuffer) {
   DJHANDLER_CHECK_ARGS(2, object, object);
   DJHANDLER_CHECK_ARG_IF_EXIST(2, function);
 
-  iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(2, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(2, function);
 
-  iotjs_spi_set_buffer(spi, *JHANDLER_GET_ARG(0, object),
-                       *JHANDLER_GET_ARG(1, object));
+  iotjs_spi_set_buffer(spi, JHANDLER_GET_ARG(0, object),
+                       JHANDLER_GET_ARG(1, object));
 
   if (!jerry_value_is_null(jcallback)) {
     SPI_ASYNC(transfer, spi, jcallback, kSpiOpTransferBuffer);
@@ -408,7 +408,7 @@ JHANDLER_FUNCTION(Close) {
 
   DJHANDLER_CHECK_ARG_IF_EXIST(0, function);
 
-  iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
+  const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
 
   if (!jerry_value_is_null(jcallback)) {
     SPI_ASYNC(close, spi, jcallback, kSpiOpClose);

--- a/src/modules/iotjs_module_stm32f4dis.c
+++ b/src/modules/iotjs_module_stm32f4dis.c
@@ -22,7 +22,7 @@ iotjs_jval_t InitStm32f4dis() {
 
 #if defined(__NUTTX__)
 
-  iotjs_stm32f4dis_pin_initialize(stm32f4dis);
+  iotjs_stm32f4dis_pin_initialize(&stm32f4dis);
 
 #endif
 

--- a/src/modules/iotjs_module_stm32f4dis.h
+++ b/src/modules/iotjs_module_stm32f4dis.h
@@ -17,7 +17,7 @@
 #define IOTJS_MODULE_STM32F4DIS_H
 
 
-void iotjs_stm32f4dis_pin_initialize(iotjs_jval_t jobj);
+void iotjs_stm32f4dis_pin_initialize(const iotjs_jval_t* jobj);
 
 
 #endif /* IOTJS_MODULE_STM32F4DIS_H */

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -1,5 +1,5 @@
 /* Copyright 2015-present Samsung Electronics Co., Ltd. and other contributors
- *
+    *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -71,7 +71,7 @@ uv_tcp_t* iotjs_tcpwrap_tcp_handle(iotjs_tcpwrap_t* tcpwrap) {
 
 iotjs_jval_t iotjs_tcpwrap_jobject(iotjs_tcpwrap_t* tcpwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_tcpwrap_t, tcpwrap);
-  return *iotjs_handlewrap_jobject(&_this->handlewrap);
+  return iotjs_handlewrap_jobject(&_this->handlewrap);
 }
 
 
@@ -81,11 +81,12 @@ iotjs_jval_t iotjs_tcpwrap_jobject(iotjs_tcpwrap_t* tcpwrap) {
 static void iotjs_connect_reqwrap_destroy(THIS);
 
 
-iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(iotjs_jval_t jcallback) {
+iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(
+    const iotjs_jval_t* jcallback) {
   iotjs_connect_reqwrap_t* connect_reqwrap =
       IOTJS_ALLOC(iotjs_connect_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_connect_reqwrap_t, connect_reqwrap);
-  iotjs_reqwrap_initialize(&_this->reqwrap, &jcallback, (uv_req_t*)&_this->req);
+  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
   return connect_reqwrap;
 }
 
@@ -162,9 +163,9 @@ uv_write_t* iotjs_write_reqwrap_req(THIS) {
 }
 
 
-iotjs_jval_t iotjs_write_reqwrap_jcallback(THIS) {
+const iotjs_jval_t* iotjs_write_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_write_reqwrap_t, write_reqwrap);
-  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 #undef THIS
@@ -219,8 +220,9 @@ JHANDLER_FUNCTION(TCP) {
   DJHANDLER_CHECK_THIS(object);
   DJHANDLER_CHECK_ARGS(0);
 
-  iotjs_jval_t jtcp = *JHANDLER_GET_THIS(object);
-  iotjs_tcpwrap_create(jtcp);
+  iotjs_jval_t jtcp = JHANDLER_GET_THIS(object);
+  iotjs_tcpwrap_t* tcp_wrap = iotjs_tcpwrap_create(jtcp);
+  IOTJS_UNUSED(tcp_wrap);
 }
 
 
@@ -233,12 +235,12 @@ void AfterClose(uv_handle_t* handle) {
   iotjs_handlewrap_t* wrap = iotjs_handlewrap_from_handle(handle);
 
   // tcp object.
-  iotjs_jval_t jtcp = *iotjs_handlewrap_jobject(wrap);
+  iotjs_jval_t jtcp = iotjs_handlewrap_jobject(wrap);
 
   // callback function.
   iotjs_jval_t jcallback =
       iotjs_jval_get_property(&jtcp, IOTJS_MAGIC_STRING_ONCLOSE);
-  if (iotjs_jval_is_function(&jcallback)) {
+  if (iotjs_jval_is_function(jcallback)) {
     iotjs_make_callback(&jcallback, iotjs_jval_get_undefined(),
                         iotjs_jargs_get_empty());
   }
@@ -290,7 +292,7 @@ static void AfterConnect(uv_connect_t* req, int status) {
   // Take callback function object.
   // function afterConnect(status)
   iotjs_jval_t jcallback = iotjs_connect_reqwrap_jcallback(req_wrap);
-  IOTJS_ASSERT(iotjs_jval_is_function(&jcallback));
+  IOTJS_ASSERT(iotjs_jval_is_function(jcallback));
 
   // Only parameter is status code.
   iotjs_jargs_t args = iotjs_jargs_create(1);
@@ -318,14 +320,14 @@ JHANDLER_FUNCTION(Connect) {
 
   iotjs_string_t address = JHANDLER_GET_ARG(0, string);
   int port = JHANDLER_GET_ARG(1, number);
-  iotjs_jval_t jcallback = *JHANDLER_GET_ARG(2, function);
+  iotjs_jval_t jcallback = JHANDLER_GET_ARG(2, function);
 
   sockaddr_in addr;
   int err = uv_ip4_addr(iotjs_string_data(&address), port, &addr);
 
   if (err == 0) {
     // Create connection request wrapper.
-    iotjs_connect_reqwrap_t* req_wrap = iotjs_connect_reqwrap_create(jcallback);
+    iotjs_connect_reqwrap_t* req_wrap = iotjs_connect_reqwrap_create(&jcallback);
 
     // Create connection request.
     err = uv_tcp_connect(iotjs_connect_reqwrap_req(req_wrap),
@@ -357,7 +359,7 @@ static void OnConnection(uv_stream_t* handle, int status) {
   // `onconnection` callback.
   iotjs_jval_t jonconnection =
       iotjs_jval_get_property(&jtcp, IOTJS_MAGIC_STRING_ONCONNECTION);
-  IOTJS_ASSERT(iotjs_jval_is_function(&jonconnection));
+  IOTJS_ASSERT(iotjs_jval_is_function(jonconnection));
 
   // The callback takes two parameter
   // [0] status
@@ -369,15 +371,15 @@ static void OnConnection(uv_stream_t* handle, int status) {
     // Create client socket handle wrapper.
     iotjs_jval_t jcreate_tcp =
         iotjs_jval_get_property(&jtcp, IOTJS_MAGIC_STRING_CREATETCP);
-    IOTJS_ASSERT(iotjs_jval_is_function(&jcreate_tcp));
+    IOTJS_ASSERT(iotjs_jval_is_function(jcreate_tcp));
 
     iotjs_jval_t jclient_tcp =
         iotjs_jhelper_call_ok(&jcreate_tcp, iotjs_jval_get_undefined(),
                               iotjs_jargs_get_empty());
-    IOTJS_ASSERT(iotjs_jval_is_object(&jclient_tcp));
+    IOTJS_ASSERT(iotjs_jval_is_object(jclient_tcp));
 
     iotjs_tcpwrap_t* tcp_wrap_client =
-        (iotjs_tcpwrap_t*)(iotjs_jval_get_object_native_handle(&jclient_tcp));
+        (iotjs_tcpwrap_t*)(iotjs_jval_get_object_native_handle(jclient_tcp));
 
     uv_stream_t* client_handle =
         (uv_stream_t*)(iotjs_tcpwrap_tcp_handle(tcp_wrap_client));
@@ -420,14 +422,14 @@ void AfterWrite(uv_write_t* req, int status) {
   IOTJS_ASSERT(tcp_wrap != NULL);
 
   // Take callback function object.
-  iotjs_jval_t jcallback = iotjs_write_reqwrap_jcallback(req_wrap);
+  const iotjs_jval_t* jcallback = iotjs_write_reqwrap_jcallback(req_wrap);
 
   // Only parameter is status code.
   iotjs_jargs_t args = iotjs_jargs_create(1);
   iotjs_jargs_append_number(&args, status);
 
   // Make callback.
-  iotjs_make_callback(&jcallback, iotjs_jval_get_undefined(), &args);
+  iotjs_make_callback(jcallback, iotjs_jval_get_undefined(), &args);
 
   // Destroy args
   iotjs_jargs_destroy(&args);
@@ -441,7 +443,7 @@ JHANDLER_FUNCTION(Write) {
   JHANDLER_DECLARE_THIS_PTR(tcpwrap, tcp_wrap);
   DJHANDLER_CHECK_ARGS(2, object, function);
 
-  const iotjs_jval_t jbuffer = *JHANDLER_GET_ARG(0, object);
+  const iotjs_jval_t jbuffer = JHANDLER_GET_ARG(0, object);
   iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(jbuffer);
   char* buffer = iotjs_bufferwrap_buffer(buffer_wrap);
   size_t len = iotjs_bufferwrap_length(buffer_wrap);
@@ -450,7 +452,7 @@ JHANDLER_FUNCTION(Write) {
   buf.base = buffer;
   buf.len = len;
 
-  iotjs_jval_t arg1 = *JHANDLER_GET_ARG(1, object);
+  iotjs_jval_t arg1 = JHANDLER_GET_ARG(1, object);
   iotjs_write_reqwrap_t* req_wrap = iotjs_write_reqwrap_create(arg1);
 
   int err = uv_write(iotjs_write_reqwrap_req(req_wrap),
@@ -484,12 +486,12 @@ void OnRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
   // socket object
   iotjs_jval_t jsocket =
       iotjs_jval_get_property(&jtcp, IOTJS_MAGIC_STRING_OWNER);
-  IOTJS_ASSERT(iotjs_jval_is_object(&jsocket));
+  IOTJS_ASSERT(iotjs_jval_is_object(jsocket));
 
   // onread callback
   iotjs_jval_t jonread =
       iotjs_jval_get_property(&jtcp, IOTJS_MAGIC_STRING_ONREAD);
-  IOTJS_ASSERT(iotjs_jval_is_function(&jonread));
+  IOTJS_ASSERT(iotjs_jval_is_function(jonread));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(4);
   iotjs_jargs_append_jval(&jargs, &jsocket);
@@ -544,7 +546,7 @@ static void AfterShutdown(uv_shutdown_t* req, int status) {
 
   // function onShutdown(status)
   iotjs_jval_t jonshutdown = iotjs_shutdown_reqwrap_jcallback(req_wrap);
-  IOTJS_ASSERT(iotjs_jval_is_function(&jonshutdown));
+  IOTJS_ASSERT(iotjs_jval_is_function(jonshutdown));
 
   iotjs_jargs_t args = iotjs_jargs_create(1);
   iotjs_jargs_append_number(&args, status);
@@ -562,7 +564,7 @@ JHANDLER_FUNCTION(Shutdown) {
 
   DJHANDLER_CHECK_ARGS(1, function);
 
-  iotjs_jval_t arg0 = *JHANDLER_GET_ARG(0, object);
+  iotjs_jval_t arg0 = JHANDLER_GET_ARG(0, object);
   iotjs_shutdown_reqwrap_t* req_wrap = iotjs_shutdown_reqwrap_create(arg0);
 
   int err = uv_shutdown(iotjs_shutdown_reqwrap_req(req_wrap),

--- a/src/modules/iotjs_module_tcp.h
+++ b/src/modules/iotjs_module_tcp.h
@@ -50,7 +50,8 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_connect_reqwrap_t);
 
 #define THIS iotjs_connect_reqwrap_t* connect_reqwrap
-iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(iotjs_jval_t jcallback);
+iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(
+    const iotjs_jval_t* jcallback);
 void iotjs_connect_reqwrap_dispatched(THIS);
 uv_connect_t* iotjs_connect_reqwrap_req(THIS);
 iotjs_jval_t iotjs_connect_reqwrap_jcallback(THIS);
@@ -66,7 +67,7 @@ typedef struct {
 iotjs_write_reqwrap_t* iotjs_write_reqwrap_create(iotjs_jval_t jcallback);
 void iotjs_write_reqwrap_dispatched(THIS);
 uv_write_t* iotjs_write_reqwrap_req(THIS);
-iotjs_jval_t iotjs_write_reqwrap_jcallback(THIS);
+const iotjs_jval_t* iotjs_write_reqwrap_jcallback(THIS);
 #undef THIS
 
 
@@ -76,7 +77,8 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_shutdown_reqwrap_t);
 
 #define THIS iotjs_shutdown_reqwrap_t* shutdown_reqwrap
-iotjs_shutdown_reqwrap_t* iotjs_shutdown_reqwrap_create(iotjs_jval_t jcallback);
+iotjs_shutdown_reqwrap_t* iotjs_shutdown_reqwrap_create(
+    iotjs_jval_t jcallback);
 void iotjs_shutdown_reqwrap_dispatched(THIS);
 uv_shutdown_t* iotjs_shutdown_reqwrap_req(THIS);
 iotjs_jval_t iotjs_shutdown_reqwrap_jcallback(THIS);
@@ -92,7 +94,7 @@ iotjs_string_t iotjs_create_ip(const iotjs_string_t* address);
     DJHANDLER_CHECK_ARGS(1, object);                                           \
                                                                                \
     iotjs_##wraptype##_t* wrap =                                               \
-        iotjs_##wraptype##_from_jobject(*JHANDLER_GET_THIS(object));           \
+        iotjs_##wraptype##_from_jobject(JHANDLER_GET_THIS(object));            \
     IOTJS_ASSERT(wrap != NULL);                                                \
                                                                                \
     sockaddr_storage storage;                                                  \
@@ -100,7 +102,7 @@ iotjs_string_t iotjs_create_ip(const iotjs_string_t* address);
     sockaddr* const addr = (sockaddr*)(&storage);                              \
     int err = function(iotjs_##wraptype##_##handletype(wrap), addr, &addrlen); \
     if (err == 0)                                                              \
-      AddressToJS(*JHANDLER_GET_ARG(0, object), addr);                         \
+      AddressToJS(JHANDLER_GET_ARG(0, object), addr);                          \
     iotjs_jhandler_return_number(jhandler, err);                               \
   }
 

--- a/src/modules/iotjs_module_testdriver.c
+++ b/src/modules/iotjs_module_testdriver.c
@@ -23,19 +23,19 @@ JHANDLER_FUNCTION(IsAliveExceptFor) {
   const iotjs_environment_t* env = iotjs_environment_get();
   uv_loop_t* loop = iotjs_environment_loop(env);
 
-  const iotjs_jval_t arg0 = *iotjs_jhandler_get_arg(jhandler, 0);
+  const iotjs_jval_t arg0 = iotjs_jhandler_get_arg(jhandler, 0);
 
-  if (iotjs_jval_is_null(&arg0)) {
+  if (iotjs_jval_is_null(arg0)) {
     int alive = uv_loop_alive(loop);
 
     iotjs_jhandler_return_boolean(jhandler, alive);
   } else {
-    JHANDLER_CHECK(iotjs_jval_is_object(&arg0));
+    JHANDLER_CHECK(iotjs_jval_is_object(arg0));
 
     iotjs_jval_t jtimer =
         iotjs_jval_get_property(&arg0, IOTJS_MAGIC_STRING_HANDLER);
 
-    iotjs_timerwrap_t* timer_wrap = iotjs_timerwrap_from_jobject(jtimer);
+    iotjs_timerwrap_t* timer_wrap = iotjs_timerwrap_from_jobject(&jtimer);
     iotjs_jval_destroy(&jtimer);
 
     bool has_active_reqs = uv_loop_has_active_reqs(loop);

--- a/src/modules/iotjs_module_timer.c
+++ b/src/modules/iotjs_module_timer.c
@@ -102,8 +102,8 @@ uv_timer_t* iotjs_timerwrap_handle(iotjs_timerwrap_t* timerwrap) {
 
 iotjs_jval_t iotjs_timerwrap_jobject(iotjs_timerwrap_t* timerwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_timerwrap_t, timerwrap);
-  iotjs_jval_t jobject = *iotjs_handlewrap_jobject(&_this->handlewrap);
-  IOTJS_ASSERT(iotjs_jval_is_object(&jobject));
+  iotjs_jval_t jobject = iotjs_handlewrap_jobject(&_this->handlewrap);
+  IOTJS_ASSERT(iotjs_jval_is_object(jobject));
   return jobject;
 }
 
@@ -117,8 +117,8 @@ iotjs_timerwrap_t* iotjs_timerwrap_from_handle(uv_timer_t* timer_handle) {
 }
 
 
-iotjs_timerwrap_t* iotjs_timerwrap_from_jobject(const iotjs_jval_t jtimer) {
-  iotjs_handlewrap_t* handlewrap = iotjs_handlewrap_from_jobject(&jtimer);
+iotjs_timerwrap_t* iotjs_timerwrap_from_jobject(const iotjs_jval_t* jtimer) {
+  iotjs_handlewrap_t* handlewrap = iotjs_handlewrap_from_jobject(jtimer);
   return (iotjs_timerwrap_t*)handlewrap;
 }
 
@@ -151,13 +151,13 @@ JHANDLER_FUNCTION(Stop) {
 JHANDLER_FUNCTION(Timer) {
   JHANDLER_CHECK_THIS(object);
 
-  const iotjs_jval_t jtimer = *JHANDLER_GET_THIS(object);
+  const iotjs_jval_t jtimer = JHANDLER_GET_THIS(object);
 
   iotjs_timerwrap_t* timer_wrap = iotjs_timerwrap_create(jtimer);
 
   iotjs_jval_t jobject = iotjs_timerwrap_jobject(timer_wrap);
-  IOTJS_ASSERT(iotjs_jval_is_object(&jobject));
-  IOTJS_ASSERT(iotjs_jval_get_object_native_handle(&jtimer) != 0);
+  IOTJS_ASSERT(iotjs_jval_is_object(jobject));
+  IOTJS_ASSERT(iotjs_jval_get_object_native_handle(jtimer) != 0);
 }
 
 

--- a/src/modules/iotjs_module_timer.h
+++ b/src/modules/iotjs_module_timer.h
@@ -28,7 +28,7 @@ typedef struct {
 
 iotjs_timerwrap_t* iotjs_timerwrap_create(const iotjs_jval_t jtimer);
 
-iotjs_timerwrap_t* iotjs_timerwrap_from_jobject(const iotjs_jval_t jtimer);
+iotjs_timerwrap_t* iotjs_timerwrap_from_jobject(const iotjs_jval_t* jtimer);
 iotjs_timerwrap_t* iotjs_timerwrap_from_handle(uv_timer_t* timer_handle);
 
 uv_timer_t* iotjs_timerwrap_handle(iotjs_timerwrap_t* timerwrap);

--- a/src/modules/iotjs_module_udp.h
+++ b/src/modules/iotjs_module_udp.h
@@ -29,7 +29,7 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_udpwrap_t);
 
 
-iotjs_udpwrap_t* iotjs_udpwrap_create(iotjs_jval_t judp);
+iotjs_udpwrap_t* iotjs_udpwrap_create(const iotjs_jval_t judp);
 
 iotjs_udpwrap_t* iotjs_udpwrap_from_handle(uv_udp_t* handle);
 iotjs_udpwrap_t* iotjs_udpwrap_from_jobject(iotjs_jval_t judp);

--- a/src/platform/linux/iotjs_module_blehcisocket-linux.c
+++ b/src/platform/linux/iotjs_module_blehcisocket-linux.c
@@ -297,9 +297,9 @@ void iotjs_blehcisocket_poll(THIS) {
       }
     }
 
-    iotjs_jval_t jhcisocket = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+    iotjs_jval_t jhcisocket = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
     iotjs_jval_t jemit = iotjs_jval_get_property(&jhcisocket, "emit");
-    IOTJS_ASSERT(iotjs_jval_is_function(&jemit));
+    IOTJS_ASSERT(iotjs_jval_is_function(jemit));
 
     iotjs_jargs_t jargs = iotjs_jargs_create(2);
     iotjs_jval_t str = iotjs_jval_create_string_raw("data");
@@ -338,9 +338,9 @@ void iotjs_blehcisocket_write(THIS, char* data, size_t length) {
 void iotjs_blehcisocket_emitErrnoError(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_blehcisocket_t, blehcisocket);
 
-  iotjs_jval_t jhcisocket = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  iotjs_jval_t jhcisocket = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t jemit = iotjs_jval_get_property(&jhcisocket, "emit");
-  IOTJS_ASSERT(iotjs_jval_is_function(&jemit));
+  IOTJS_ASSERT(iotjs_jval_is_function(jemit));
 
   iotjs_jargs_t jargs = iotjs_jargs_create(2);
   iotjs_jval_t str = iotjs_jval_create_string_raw("error");

--- a/src/platform/linux/iotjs_module_gpio-linux.c
+++ b/src/platform/linux/iotjs_module_gpio-linux.c
@@ -79,9 +79,9 @@ static void gpio_set_value_fd(iotjs_gpio_t* gpio, int fd) {
 static void gpio_emit_change_event(iotjs_gpio_t* gpio) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_gpio_t, gpio);
 
-  iotjs_jval_t jgpio = *iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
+  iotjs_jval_t jgpio = iotjs_jobjectwrap_jobject(&_this->jobjectwrap);
   iotjs_jval_t jonChange = iotjs_jval_get_property(&jgpio, "onChange");
-  IOTJS_ASSERT(iotjs_jval_is_function(&jonChange));
+  IOTJS_ASSERT(iotjs_jval_is_function(jonChange));
 
   iotjs_jhelper_call_ok(&jonChange, &jgpio, iotjs_jargs_get_empty());
 

--- a/src/platform/nuttx/iotjs_module_stm32f4dis-nuttx.c
+++ b/src/platform/nuttx/iotjs_module_stm32f4dis-nuttx.c
@@ -24,7 +24,7 @@
 
 
 #if ENABLE_MODULE_ADC
-static void iotjs_pin_initialize_adc(iotjs_jval_t jobj) {
+static void iotjs_pin_initialize_adc(const iotjs_jval_t* jobj) {
   unsigned int number_bit;
 
 // ADC pin name is "ADC.(number)_(timer)".
@@ -32,7 +32,7 @@ static void iotjs_pin_initialize_adc(iotjs_jval_t jobj) {
   number_bit = (GPIO_ADC##number##_IN##timer); \
   number_bit |= (ADC_NUMBER(number));          \
   number_bit |= (SYSIO_TIMER_NUMBER(timer));   \
-  iotjs_jval_set_property_number(&jobj, "ADC" #number "_" #timer, number_bit);
+  iotjs_jval_set_property_number(jobj, "ADC" #number "_" #timer, number_bit);
 
 #define SET_ADC_CONSTANT_NUMBER(number) \
   SET_ADC_CONSTANT(number, 0);          \
@@ -64,11 +64,11 @@ static void iotjs_pin_initialize_adc(iotjs_jval_t jobj) {
 
 #if ENABLE_MODULE_GPIO
 
-static void iotjs_pin_initialize_gpio(iotjs_jval_t jobj) {
+static void iotjs_pin_initialize_gpio(const iotjs_jval_t* jobj) {
 // Set GPIO pin from configuration bits of nuttx.
 // GPIO pin name is "P(port)(pin)".
-#define SET_GPIO_CONSTANT(port, pin)                    \
-  iotjs_jval_set_property_number(&jobj, "P" #port #pin, \
+#define SET_GPIO_CONSTANT(port, pin)                   \
+  iotjs_jval_set_property_number(jobj, "P" #port #pin, \
                                  (GPIO_PORT##port | GPIO_PIN##pin));
 
 #define SET_GPIO_CONSTANT_PORT(port) \
@@ -107,7 +107,7 @@ static void iotjs_pin_initialize_gpio(iotjs_jval_t jobj) {
 
 #if ENABLE_MODULE_PWM
 
-static void iotjs_pin_initialize_pwm(iotjs_jval_t jobj) {
+static void iotjs_pin_initialize_pwm(const iotjs_jval_t* jobj) {
   unsigned int timer_bit;
 
 // Set PWM pin from configuration bits of nuttx.
@@ -124,7 +124,7 @@ static void iotjs_pin_initialize_pwm(iotjs_jval_t jobj) {
 
 #define SET_GPIO_CONSTANT_TIM(timer)                     \
   iotjs_jval_t jtim##timer = iotjs_jval_create_object(); \
-  iotjs_jval_set_property_jval(&jobj, "PWM" #timer, &jtim##timer);
+  iotjs_jval_set_property_jval(jobj, "PWM" #timer, &jtim##timer);
 
 #define SET_GPIO_CONSTANT_TIM_1(timer) \
   SET_GPIO_CONSTANT_TIM(timer);        \
@@ -181,20 +181,20 @@ static void iotjs_pin_initialize_pwm(iotjs_jval_t jobj) {
 #endif /* ENABLE_MODULE_PWM */
 
 
-void iotjs_stm32f4dis_pin_initialize(iotjs_jval_t jobj) {
+void iotjs_stm32f4dis_pin_initialize(const iotjs_jval_t* jobj) {
   iotjs_jval_t jpin = iotjs_jval_create_object();
-  iotjs_jval_set_property_jval(&jobj, "pin", &jpin);
+  iotjs_jval_set_property_jval(jobj, "pin", &jpin);
 
 #if ENABLE_MODULE_ADC
-  iotjs_pin_initialize_adc(jpin);
+  iotjs_pin_initialize_adc(&jpin);
 #endif /* ENABLE_MODULE_ADC */
 
 #if ENABLE_MODULE_GPIO
-  iotjs_pin_initialize_gpio(jpin);
+  iotjs_pin_initialize_gpio(&jpin);
 #endif /* ENABLE_MODULE_GPIO */
 
 #if ENABLE_MODULE_PWM
-  iotjs_pin_initialize_pwm(jpin);
+  iotjs_pin_initialize_pwm(&jpin);
 #endif /* ENABLE_MODULE_PWM */
 
   iotjs_jval_destroy(&jpin);


### PR DESCRIPTION
* Changed 'iotjs_jval_as_*' functions
 * Changed 'iotjs_jval_is_*' functions
 * Updated the call sites

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com