### PR TITLE
Fix static analysis error(160318) (#1237)

### DIFF
--- a/src/modules/iotjs_module_dns.c
+++ b/src/modules/iotjs_module_dns.c
@@ -197,7 +197,7 @@ JHANDLER_FUNCTION(GetAddrInfo) {
   const char* hostname_data = iotjs_string_data(&hostname);
 
   if (strcmp(hostname_data, "localhost") == 0) {
-    strcpy(ip, "127.0.0.1");
+    strncpy(ip, "127.0.0.1", strlen("127.0.0.1") + 1);
   } else {
     struct sockaddr_in addr;
 


### PR DESCRIPTION
SVACE error fix (160318)
 Use of vulnerable function 'strcpy' at iotjs_module_dns.c
 It's changed to 'strncpy'

IoT.js-DCO-1.0-Signed-off-by: Haesik, Jun haesik.jun@samsung.com