### PR TITLE
Remove unused import from build.py (#1267)

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -27,7 +27,6 @@ import sys
 import re
 import os
 
-from js2c import js2c
 from common_py import path
 from common_py.system.filesystem import FileSystem as fs
 from common_py.system.executor import Executor as ex


### PR DESCRIPTION
The js2c is not used in the build.py
thus we can remove it.

IoT.js-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com