### PR TITLE
Fix an issue causing stderr to close (#1268)

### DIFF
--- a/src/iotjs_debuglog.c
+++ b/src/iotjs_debuglog.c
@@ -56,7 +56,7 @@ void init_debug_settings() {
 
 void release_debug_settings() {
 #ifdef ENABLE_DEBUG_LOG
-  if (iotjs_log_stream != stderr || iotjs_log_stream != stdout) {
+  if (iotjs_log_stream != stderr && iotjs_log_stream != stdout) {
     fclose(iotjs_log_stream);
   }
   // some embed systems(ex, nuttx) may need this


### PR DESCRIPTION
This issue might also be present in libtuv/src/tuv_debuglog.c

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu