### PR TITLE
Change the way debugger options are handled (#1259)

### DIFF
--- a/src/iotjs.c
+++ b/src/iotjs.c
@@ -54,11 +54,8 @@ static bool iotjs_jerry_initialize(iotjs_environment_t* env) {
   // Initialize jerry.
   jerry_init(jerry_flags);
 
-  if (iotjs_environment_config(env)->debugger) {
-    jerry_debugger_init(iotjs_environment_config(env)->debugger_port);
-  }
-
-  if (iotjs_environment_config(env)->debugger) {
+  if (iotjs_environment_config(env)->debugger != NULL) {
+    jerry_debugger_init(iotjs_environment_config(env)->debugger->port);
     jerry_debugger_continue();
   }
 

--- a/src/iotjs_env.h
+++ b/src/iotjs_env.h
@@ -18,13 +18,15 @@
 
 #include "uv.h"
 
+typedef struct {
+  bool wait_source;
+  int port;
+} DebuggerConfig;
 
 typedef struct {
   bool memstat;
   bool show_opcode;
-  bool debugger;
-  bool debugger_wait_source;
-  int debugger_port;
+  DebuggerConfig* debugger;
 } Config;
 
 typedef enum {
@@ -67,6 +69,7 @@ uv_loop_t* iotjs_environment_loop(const iotjs_environment_t* env);
 void iotjs_environment_set_loop(iotjs_environment_t* env, uv_loop_t* loop);
 
 const Config* iotjs_environment_config(const iotjs_environment_t* env);
+const DebuggerConfig* iotjs_environment_dconfig(const iotjs_environment_t* env);
 
 void iotjs_environment_go_state_running_main(iotjs_environment_t* env);
 void iotjs_environment_go_state_running_loop(iotjs_environment_t* env);

--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -55,7 +55,7 @@ JHANDLER_FUNCTION(Compile) {
   const char* filename = iotjs_string_data(&file);
   const iotjs_environment_t* env = iotjs_environment_get();
 
-  if (iotjs_environment_config(env)->debugger) {
+  if (iotjs_environment_config(env)->debugger != NULL) {
     jerry_debugger_stop();
   }
 
@@ -317,9 +317,13 @@ iotjs_jval_t InitProcess() {
 
   // Set iotjs
   SetProcessIotjs(process);
-
-  bool wait_source =
-      iotjs_environment_config(iotjs_environment_get())->debugger_wait_source;
+  bool wait_source;
+  if (iotjs_environment_config(iotjs_environment_get())->debugger != NULL) {
+    wait_source = iotjs_environment_config(iotjs_environment_get())
+                      ->debugger->wait_source;
+  } else {
+    wait_source = false;
+  }
 
   if (!wait_source) {
     SetProcessArgv(process);


### PR DESCRIPTION
Since debugger options are turned on after compiling the program, there's no proper way to handle them memory-wise.
However, creating a seperate structure for them makes it possible not to allocate memory at the beginning, if debugger is not turned on.
Moreover, later on there might be more debugger specific options (ie. context reset), therefore we can save more memory.

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu