### PR TITLE
Removed 'iotjs_jval_t' pointer (#1261)

### DIFF
--- a/src/iotjs_binding.c
+++ b/src/iotjs_binding.c
@@ -21,12 +21,7 @@
 #include <string.h>
 
 
-static iotjs_jval_t jundefined;
-static iotjs_jval_t jnull;
-static iotjs_jval_t jtrue;
-static iotjs_jval_t jfalse;
 static iotjs_jval_t jglobal;
-
 static iotjs_jargs_t jargs_empty;
 
 
@@ -130,21 +125,6 @@ static iotjs_jval_t iotjs_jval_create_raw(jerry_value_t val) {
 }
 
 
-iotjs_jval_t* iotjs_jval_get_undefined() {
-  return &jundefined;
-}
-
-
-iotjs_jval_t* iotjs_jval_get_null() {
-  return &jnull;
-}
-
-
-iotjs_jval_t* iotjs_jval_get_boolean(bool v) {
-  return v ? &jtrue : &jfalse;
-}
-
-
 iotjs_jval_t iotjs_jval_get_global_object() {
   return jglobal;
 }
@@ -245,18 +225,18 @@ void iotjs_jval_set_property_jval(iotjs_jval_t jobj, const char* name,
 
 
 void iotjs_jval_set_property_null(iotjs_jval_t jobj, const char* name) {
-  iotjs_jval_set_property_jval(jobj, name, *iotjs_jval_get_null());
+  iotjs_jval_set_property_jval(jobj, name, jerry_create_null());
 }
 
 
 void iotjs_jval_set_property_undefined(iotjs_jval_t jobj, const char* name) {
-  iotjs_jval_set_property_jval(jobj, name, *iotjs_jval_get_undefined());
+  iotjs_jval_set_property_jval(jobj, name, jerry_create_undefined());
 }
 
 
 void iotjs_jval_set_property_boolean(iotjs_jval_t jobj, const char* name,
                                      bool v) {
-  iotjs_jval_set_property_jval(jobj, name, *iotjs_jval_get_boolean(v));
+  iotjs_jval_set_property_jval(jobj, name, jerry_create_boolean(v));
 }
 
 
@@ -293,7 +273,7 @@ iotjs_jval_t iotjs_jval_get_property(iotjs_jval_t jobj, const char* name) {
 
   if (jerry_value_has_error_flag(res)) {
     jerry_release_value(res);
-    return jerry_acquire_value(*iotjs_jval_get_undefined());
+    return jerry_acquire_value(jerry_create_undefined());
   }
 
   return iotjs_jval_create_raw(res);
@@ -381,7 +361,7 @@ iotjs_jval_t iotjs_jval_get_property_by_index(iotjs_jval_t jarr, uint32_t idx) {
 
   if (jerry_value_has_error_flag(res)) {
     jerry_release_value(res);
-    return *iotjs_jval_get_undefined();
+    return jerry_create_undefined();
   }
 
   return res;
@@ -554,19 +534,19 @@ void iotjs_jargs_append_jval(iotjs_jargs_t* jargs, iotjs_jval_t x) {
 
 void iotjs_jargs_append_undefined(iotjs_jargs_t* jargs) {
   IOTJS_VALIDATABLE_STRUCT_METHOD_VALIDATE(iotjs_jargs_t, jargs);
-  iotjs_jargs_append_jval(jargs, *iotjs_jval_get_undefined());
+  iotjs_jargs_append_jval(jargs, jerry_create_undefined());
 }
 
 
 void iotjs_jargs_append_null(iotjs_jargs_t* jargs) {
   IOTJS_VALIDATABLE_STRUCT_METHOD_VALIDATE(iotjs_jargs_t, jargs);
-  iotjs_jargs_append_jval(jargs, *iotjs_jval_get_null());
+  iotjs_jargs_append_jval(jargs, jerry_create_null());
 }
 
 
 void iotjs_jargs_append_bool(iotjs_jargs_t* jargs, bool x) {
   IOTJS_VALIDATABLE_STRUCT_METHOD_VALIDATE(iotjs_jargs_t, jargs);
-  iotjs_jargs_append_jval(jargs, *iotjs_jval_get_boolean(x));
+  iotjs_jargs_append_jval(jargs, jerry_create_boolean(x));
 }
 
 
@@ -621,7 +601,7 @@ void iotjs_jhandler_initialize(iotjs_jhandler_t* jhandler,
 
   _this->jfunc = iotjs_jval_create_raw(jfunc);
   _this->jthis = iotjs_jval_create_raw(jthis);
-  _this->jret = jerry_acquire_value(*iotjs_jval_get_undefined());
+  _this->jret = jerry_acquire_value(jerry_create_undefined());
 #ifdef NDEBUG
   _this->jargv = (iotjs_jval_t*)jargv;
 #else
@@ -697,19 +677,19 @@ void iotjs_jhandler_return_jval(iotjs_jhandler_t* jhandler,
 
 void iotjs_jhandler_return_undefined(iotjs_jhandler_t* jhandler) {
   IOTJS_VALIDATABLE_STRUCT_METHOD_VALIDATE(iotjs_jhandler_t, jhandler);
-  iotjs_jhandler_return_jval(jhandler, *iotjs_jval_get_undefined());
+  iotjs_jhandler_return_jval(jhandler, jerry_create_undefined());
 }
 
 
 void iotjs_jhandler_return_null(iotjs_jhandler_t* jhandler) {
   IOTJS_VALIDATABLE_STRUCT_METHOD_VALIDATE(iotjs_jhandler_t, jhandler);
-  iotjs_jhandler_return_jval(jhandler, *iotjs_jval_get_null());
+  iotjs_jhandler_return_jval(jhandler, jerry_create_null());
 }
 
 
 void iotjs_jhandler_return_boolean(iotjs_jhandler_t* jhandler, bool ret) {
   IOTJS_VALIDATABLE_STRUCT_METHOD_VALIDATE(iotjs_jhandler_t, jhandler);
-  iotjs_jhandler_return_jval(jhandler, *iotjs_jval_get_boolean(ret));
+  iotjs_jhandler_return_jval(jhandler, jerry_create_boolean(ret));
 }
 
 
@@ -797,11 +777,7 @@ iotjs_jval_t iotjs_jval_create_function_with_dispatch(
 
 
 void iotjs_binding_initialize() {
-  jundefined = iotjs_jval_create_raw(jerry_create_undefined());
-  jnull = iotjs_jval_create_raw(jerry_create_null());
-  jtrue = iotjs_jval_create_raw(jerry_create_boolean(true));
-  jfalse = iotjs_jval_create_raw(jerry_create_boolean(false));
-  jglobal = iotjs_jval_create_raw(jerry_get_global_object());
+  jglobal = jerry_get_global_object();
 
   IOTJS_ASSERT(iotjs_jval_is_object(jglobal));
 
@@ -814,10 +790,6 @@ void iotjs_binding_initialize() {
 
 
 void iotjs_binding_finalize() {
-  jerry_release_value(jundefined);
-  jerry_release_value(jnull);
-  jerry_release_value(jtrue);
-  jerry_release_value(jfalse);
   jerry_release_value(jglobal);
   iotjs_jargs_destroy(&jargs_empty);
 }

--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -81,10 +81,6 @@ iotjs_jval_t iotjs_jval_create_error(const char* msg);
 iotjs_jval_t iotjs_jval_create_error_type(iotjs_error_t type, const char* msg);
 
 iotjs_jval_t iotjs_jval_get_string_size(const iotjs_string_t* str);
-
-iotjs_jval_t* iotjs_jval_get_undefined();
-iotjs_jval_t* iotjs_jval_get_null();
-iotjs_jval_t* iotjs_jval_get_boolean(bool v);
 iotjs_jval_t iotjs_jval_get_global_object();
 
 
@@ -275,7 +271,7 @@ static inline bool ge(uint16_t a, uint16_t b) {
   ((iotjs_jhandler_get_arg_length(jhandler) > index) &&                  \
            iotjs_jval_is_##type(iotjs_jhandler_get_arg(jhandler, index)) \
        ? iotjs_jhandler_get_arg(jhandler, index)                         \
-       : *iotjs_jval_get_null())
+       : jerry_create_null())
 
 #define JHANDLER_GET_THIS(type) \
   iotjs_jval_as_##type(iotjs_jhandler_get_this(jhandler))

--- a/src/iotjs_binding_helper.c
+++ b/src/iotjs_binding_helper.c
@@ -87,7 +87,7 @@ bool iotjs_process_next_tick() {
   IOTJS_ASSERT(iotjs_jval_is_function(jon_next_tick));
 
   iotjs_jval_t jres =
-      iotjs_jhelper_call_ok(jon_next_tick, *iotjs_jval_get_undefined(),
+      iotjs_jhelper_call_ok(jon_next_tick, jerry_create_undefined(),
                             iotjs_jargs_get_empty());
 
   IOTJS_ASSERT(iotjs_jval_is_boolean(jres));

--- a/src/iotjs_module.c
+++ b/src/iotjs_module.c
@@ -36,9 +36,9 @@ MAP_MODULE_LIST(DECLARE_MODULE_INITIALIZER)
 #undef DECLARE_MODULE_INITIALIZER
 
 
-#define INIT_MODULE_LIST(upper, Camel, lower)                    \
-  modules[MODULE_##upper].kind = MODULE_##upper;                 \
-  modules[MODULE_##upper].jmodule = *iotjs_jval_get_undefined(); \
+#define INIT_MODULE_LIST(upper, Camel, lower)                 \
+  modules[MODULE_##upper].kind = MODULE_##upper;              \
+  modules[MODULE_##upper].jmodule = jerry_create_undefined(); \
   modules[MODULE_##upper].fn_register = Init##Camel;
 
 void iotjs_module_list_init() {

--- a/src/modules/iotjs_module_adc.c
+++ b/src/modules/iotjs_module_adc.c
@@ -153,8 +153,8 @@ static void iotjs_adc_after_work(uv_work_t* work_req, int status) {
     }
   }
 
-  iotjs_jval_t jcallback = iotjs_adc_reqwrap_jcallback(req_wrap);
-  iotjs_make_callback(jcallback, *iotjs_jval_get_undefined(), &jargs);
+  const iotjs_jval_t jcallback = iotjs_adc_reqwrap_jcallback(req_wrap);
+  iotjs_make_callback(jcallback, jerry_create_undefined(), &jargs);
 
   iotjs_jargs_destroy(&jargs);
 

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -223,7 +223,7 @@ iotjs_jval_t iotjs_bufferwrap_create_buffer(size_t len) {
   iotjs_jargs_append_number(&jargs, len);
 
   iotjs_jval_t jres =
-      iotjs_jhelper_call_ok(jbuffer, *iotjs_jval_get_undefined(), &jargs);
+      iotjs_jhelper_call_ok(jbuffer, jerry_create_undefined(), &jargs);
   IOTJS_ASSERT(iotjs_jval_is_object(jres));
 
   iotjs_jargs_destroy(&jargs);

--- a/src/modules/iotjs_module_dns.c
+++ b/src/modules/iotjs_module_dns.c
@@ -155,7 +155,7 @@ static void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status,
 
   // Make the callback into JavaScript
   iotjs_jval_t jcallback = iotjs_getaddrinfo_reqwrap_jcallback(req_wrap);
-  iotjs_make_callback(jcallback, *iotjs_jval_get_undefined(), &args);
+  iotjs_make_callback(jcallback, jerry_create_undefined(), &args);
 
   iotjs_jargs_destroy(&args);
 
@@ -217,7 +217,7 @@ JHANDLER_FUNCTION(GetAddrInfo) {
   iotjs_jargs_append_string_raw(&args, ip);
   iotjs_jargs_append_number(&args, option);
 
-  iotjs_make_callback(jcallback, *iotjs_jval_get_undefined(), &args);
+  iotjs_make_callback(jcallback, jerry_create_undefined(), &args);
   iotjs_jargs_destroy(&args);
   IOTJS_UNUSED(flags);
 #else

--- a/src/modules/iotjs_module_fs.c
+++ b/src/modules/iotjs_module_fs.c
@@ -99,7 +99,7 @@ static void AfterAsync(uv_fs_t* req) {
     }
   }
 
-  iotjs_make_callback(cb, *iotjs_jval_get_undefined(), &jarg);
+  iotjs_make_callback(cb, jerry_create_undefined(), &jarg);
 
   iotjs_jargs_destroy(&jarg);
   iotjs_fs_reqwrap_destroy(req_wrap);

--- a/src/modules/iotjs_module_gpio.c
+++ b/src/modules/iotjs_module_gpio.c
@@ -195,7 +195,7 @@ static void iotjs_gpio_after_worker(uv_work_t* work_req, int status) {
   }
 
   iotjs_jval_t jcallback = iotjs_gpio_reqwrap_jcallback(req_wrap);
-  iotjs_make_callback(jcallback, *iotjs_jval_get_undefined(), &jargs);
+  iotjs_make_callback(jcallback, jerry_create_undefined(), &jargs);
 
   iotjs_jargs_destroy(&jargs);
 

--- a/src/modules/iotjs_module_httpparser.c
+++ b/src/modules/iotjs_module_httpparser.c
@@ -66,7 +66,7 @@ static void iotjs_httpparserwrap_initialize(
   _this->n_fields = 0;
   _this->n_values = 0;
   _this->flushed = false;
-  _this->cur_jbuf = *iotjs_jval_get_null();
+  _this->cur_jbuf = jerry_create_null();
   _this->cur_buf = NULL;
   _this->cur_buf_len = 0;
 }
@@ -426,7 +426,7 @@ JHANDLER_FUNCTION(Execute) {
   size_t nparsed =
       http_parser_execute(nativeparser, &settings, buf_data, buf_len);
 
-  iotjs_httpparserwrap_set_buf(parser, *iotjs_jval_get_null(), NULL, 0);
+  iotjs_httpparserwrap_set_buf(parser, jerry_create_null(), NULL, 0);
 
 
   if (!nativeparser->upgrade && nparsed != buf_len) {

--- a/src/modules/iotjs_module_i2c.c
+++ b/src/modules/iotjs_module_i2c.c
@@ -165,7 +165,7 @@ void AfterI2CWork(uv_work_t* work_req, int status) {
   }
 
   const iotjs_jval_t jcallback = iotjs_i2c_reqwrap_jcallback(req_wrap);
-  iotjs_make_callback(jcallback, *iotjs_jval_get_undefined(), &jargs);
+  iotjs_make_callback(jcallback, jerry_create_undefined(), &jargs);
 
   iotjs_jargs_destroy(&jargs);
   iotjs_i2c_reqwrap_dispatched(req_wrap);

--- a/src/modules/iotjs_module_process.c
+++ b/src/modules/iotjs_module_process.c
@@ -210,8 +210,8 @@ JHANDLER_FUNCTION(DoExit) {
 
 void SetNativeSources(iotjs_jval_t native_sources) {
   for (int i = 0; natives[i].name; i++) {
-        iotjs_jval_set_property_jval(native_sources, natives[i].name,
-                                 *iotjs_jval_get_boolean(true));
+    iotjs_jval_set_property_jval(native_sources, natives[i].name,
+                                 jerry_create_boolean(true));
   }
 }
 
@@ -325,7 +325,7 @@ iotjs_jval_t InitProcess() {
     SetProcessArgv(process);
   }
 
-  iotjs_jval_t wait_source_val = *iotjs_jval_get_boolean(wait_source);
+  iotjs_jval_t wait_source_val = jerry_create_boolean(wait_source);
   iotjs_jval_set_property_jval(process, IOTJS_MAGIC_STRING_DEBUGGER_WAIT_SOURCE,
                                wait_source_val);
 

--- a/src/modules/iotjs_module_pwm.c
+++ b/src/modules/iotjs_module_pwm.c
@@ -215,7 +215,7 @@ static void iotjs_pwm_after_worker(uv_work_t* work_req, int status) {
   }
 
   iotjs_jval_t jcallback = iotjs_pwm_reqwrap_jcallback(req_wrap);
-  iotjs_make_callback(jcallback, *iotjs_jval_get_undefined(), &jargs);
+  iotjs_make_callback(jcallback, jerry_create_undefined(), &jargs);
 
   iotjs_jargs_destroy(&jargs);
 

--- a/src/modules/iotjs_module_spi.c
+++ b/src/modules/iotjs_module_spi.c
@@ -301,7 +301,7 @@ static void iotjs_spi_after_work(uv_work_t* work_req, int status) {
   }
 
   iotjs_jval_t jcallback = iotjs_spi_reqwrap_jcallback(req_wrap);
-  iotjs_make_callback(jcallback, *iotjs_jval_get_undefined(), &jargs);
+  iotjs_make_callback(jcallback, jerry_create_undefined(), &jargs);
 
   iotjs_jargs_destroy(&jargs);
 

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -241,7 +241,7 @@ void AfterClose(uv_handle_t* handle) {
   iotjs_jval_t jcallback =
       iotjs_jval_get_property(jtcp, IOTJS_MAGIC_STRING_ONCLOSE);
   if (iotjs_jval_is_function(jcallback)) {
-    iotjs_make_callback(jcallback, *iotjs_jval_get_undefined(),
+    iotjs_make_callback(jcallback, jerry_create_undefined(),
                         iotjs_jargs_get_empty());
   }
   jerry_release_value(jcallback);
@@ -299,7 +299,7 @@ static void AfterConnect(uv_connect_t* req, int status) {
   iotjs_jargs_append_number(&args, status);
 
   // Make callback.
-  iotjs_make_callback(jcallback, *iotjs_jval_get_undefined(), &args);
+  iotjs_make_callback(jcallback, jerry_create_undefined(), &args);
 
   // Destroy args
   iotjs_jargs_destroy(&args);
@@ -374,7 +374,7 @@ static void OnConnection(uv_stream_t* handle, int status) {
     IOTJS_ASSERT(iotjs_jval_is_function(jcreate_tcp));
 
     iotjs_jval_t jclient_tcp =
-        iotjs_jhelper_call_ok(jcreate_tcp, *iotjs_jval_get_undefined(),
+        iotjs_jhelper_call_ok(jcreate_tcp, jerry_create_undefined(),
                               iotjs_jargs_get_empty());
     IOTJS_ASSERT(iotjs_jval_is_object(jclient_tcp));
 
@@ -429,7 +429,7 @@ void AfterWrite(uv_write_t* req, int status) {
   iotjs_jargs_append_number(&args, status);
 
   // Make callback.
-  iotjs_make_callback(jcallback, *iotjs_jval_get_undefined(), &args);
+  iotjs_make_callback(jcallback, jerry_create_undefined(), &args);
 
   // Destroy args
   iotjs_jargs_destroy(&args);
@@ -504,10 +504,10 @@ void OnRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
     }
     if (nread < 0) {
       if (nread == UV__EOF) {
-        iotjs_jargs_replace(&jargs, 2, *iotjs_jval_get_boolean(true));
+        iotjs_jargs_replace(&jargs, 2, jerry_create_boolean(true));
       }
 
-      iotjs_make_callback(jonread, *iotjs_jval_get_undefined(), &jargs);
+      iotjs_make_callback(jonread, jerry_create_undefined(), &jargs);
     }
   } else {
     iotjs_jval_t jbuffer = iotjs_bufferwrap_create_buffer((size_t)nread);
@@ -516,7 +516,7 @@ void OnRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf) {
     iotjs_bufferwrap_copy(buffer_wrap, buf->base, (size_t)nread);
 
     iotjs_jargs_append_jval(&jargs, jbuffer);
-    iotjs_make_callback(jonread, *iotjs_jval_get_undefined(), &jargs);
+    iotjs_make_callback(jonread, jerry_create_undefined(), &jargs);
 
     jerry_release_value(jbuffer);
     iotjs_buffer_release(buf->base);
@@ -551,7 +551,7 @@ static void AfterShutdown(uv_shutdown_t* req, int status) {
   iotjs_jargs_t args = iotjs_jargs_create(1);
   iotjs_jargs_append_number(&args, status);
 
-  iotjs_make_callback(jonshutdown, *iotjs_jval_get_undefined(), &args);
+  iotjs_make_callback(jonshutdown, jerry_create_undefined(), &args);
 
   iotjs_jargs_destroy(&args);
 

--- a/src/modules/iotjs_module_uart.c
+++ b/src/modules/iotjs_module_uart.c
@@ -203,7 +203,7 @@ static void iotjs_uart_after_worker(uv_work_t* work_req, int status) {
   }
 
   iotjs_jval_t jcallback = iotjs_uart_reqwrap_jcallback(req_wrap);
-  iotjs_make_callback(jcallback, *iotjs_jval_get_undefined(), &jargs);
+  iotjs_make_callback(jcallback, jerry_create_undefined(), &jargs);
 
   iotjs_jargs_destroy(&jargs);
   iotjs_uart_reqwrap_dispatched(req_wrap);

--- a/src/modules/iotjs_module_udp.c
+++ b/src/modules/iotjs_module_udp.c
@@ -207,7 +207,7 @@ static void OnRecv(uv_udp_t* handle, ssize_t nread, const uv_buf_t* buf,
   if (nread < 0) {
     if (buf->base != NULL)
       iotjs_buffer_release(buf->base);
-    iotjs_make_callback(jonmessage, *iotjs_jval_get_undefined(), &jargs);
+    iotjs_make_callback(jonmessage, jerry_create_undefined(), &jargs);
     jerry_release_value(jonmessage);
     iotjs_jargs_destroy(&jargs);
     return;
@@ -224,7 +224,7 @@ static void OnRecv(uv_udp_t* handle, ssize_t nread, const uv_buf_t* buf,
   AddressToJS(rinfo, addr);
   iotjs_jargs_append_jval(&jargs, rinfo);
 
-  iotjs_make_callback(jonmessage, *iotjs_jval_get_undefined(), &jargs);
+  iotjs_make_callback(jonmessage, jerry_create_undefined(), &jargs);
 
   jerry_release_value(rinfo);
   jerry_release_value(jbuffer);
@@ -273,7 +273,7 @@ static void OnSend(uv_udp_send_t* req, int status) {
     iotjs_jargs_append_number(&jargs, status);
     iotjs_jargs_append_number(&jargs, iotjs_send_reqwrap_msg_size(req_wrap));
 
-    iotjs_make_callback(jcallback, *iotjs_jval_get_undefined(), &jargs);
+    iotjs_make_callback(jcallback, jerry_create_undefined(), &jargs);
     iotjs_jargs_destroy(&jargs);
   }
 


### PR DESCRIPTION
Removed 'iotjs_jval_t' pointer from 'iotjs_jval_get_undefined', 'iotjs_jval_get_null' and 'iotjs_jval_get_boolean'.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com