### PR TITLE
Removed 'iotjs_jval_t' pointer (#1271)

### DIFF
--- a/src/iotjs_handlewrap.c
+++ b/src/iotjs_handlewrap.c
@@ -25,7 +25,7 @@ void iotjs_handlewrap_initialize(iotjs_handlewrap_t* handlewrap,
   // Increase ref count of Javascript object to guarantee it is alive until the
   // handle has closed.
   iotjs_jval_t jobjectref = jerry_acquire_value(jobject);
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, &jobjectref, native_info);
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jobjectref, native_info);
 
   _this->handle = handle;
   _this->on_close_cb = NULL;

--- a/src/iotjs_objectwrap.c
+++ b/src/iotjs_objectwrap.c
@@ -18,15 +18,15 @@
 
 
 void iotjs_jobjectwrap_initialize(iotjs_jobjectwrap_t* jobjectwrap,
-                                  const iotjs_jval_t* jobject,
+                                  iotjs_jval_t jobject,
                                   JNativeInfoType* native_info) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_jobjectwrap_t, jobjectwrap);
 
-  IOTJS_ASSERT(iotjs_jval_is_object(*jobject));
+  IOTJS_ASSERT(iotjs_jval_is_object(jobject));
 
   // This wrapper holds pointer to the javascript object but never increases
   // reference count.
-  _this->jobject = *((iotjs_jval_t*)jobject);
+  _this->jobject = jobject;
 
   // Set native pointer of the object to be this wrapper.
   // If the object is freed by GC, the wrapper instance should also be freed.
@@ -51,10 +51,9 @@ iotjs_jval_t iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap) {
 }
 
 
-iotjs_jobjectwrap_t* iotjs_jobjectwrap_from_jobject(
-    const iotjs_jval_t* jobject) {
+iotjs_jobjectwrap_t* iotjs_jobjectwrap_from_jobject(iotjs_jval_t jobject) {
   iotjs_jobjectwrap_t* wrap =
-      (iotjs_jobjectwrap_t*)(iotjs_jval_get_object_native_handle(*jobject));
+      (iotjs_jobjectwrap_t*)(iotjs_jval_get_object_native_handle(jobject));
   IOTJS_ASSERT(iotjs_jval_is_object(iotjs_jobjectwrap_jobject(wrap)));
   return wrap;
 }

--- a/src/iotjs_objectwrap.h
+++ b/src/iotjs_objectwrap.h
@@ -27,14 +27,13 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_jobjectwrap_t);
 
 void iotjs_jobjectwrap_initialize(iotjs_jobjectwrap_t* jobjectwrap,
-                                  const iotjs_jval_t* jobject,
+                                  iotjs_jval_t jobject,
                                   JNativeInfoType* native_info);
 
 void iotjs_jobjectwrap_destroy(iotjs_jobjectwrap_t* jobjectwrap);
 
 iotjs_jval_t iotjs_jobjectwrap_jobject(iotjs_jobjectwrap_t* jobjectwrap);
-iotjs_jobjectwrap_t* iotjs_jobjectwrap_from_jobject(
-    const iotjs_jval_t* jobject);
+iotjs_jobjectwrap_t* iotjs_jobjectwrap_from_jobject(iotjs_jval_t jobject);
 
 #define IOTJS_DEFINE_NATIVE_HANDLE_INFO(module)                              \
   static const jerry_object_native_info_t module##_native_info = {           \

--- a/src/iotjs_reqwrap.c
+++ b/src/iotjs_reqwrap.c
@@ -17,12 +17,11 @@
 #include "iotjs_reqwrap.h"
 
 
-void iotjs_reqwrap_initialize(iotjs_reqwrap_t* reqwrap,
-                              const iotjs_jval_t* jcallback,
+void iotjs_reqwrap_initialize(iotjs_reqwrap_t* reqwrap, iotjs_jval_t jcallback,
                               uv_req_t* request) {
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_reqwrap_t, reqwrap);
-  IOTJS_ASSERT(iotjs_jval_is_function(*jcallback));
-  _this->jcallback = jerry_acquire_value(*jcallback);
+  IOTJS_ASSERT(iotjs_jval_is_function(jcallback));
+  _this->jcallback = jerry_acquire_value(jcallback);
   _this->request = request;
   _this->request->data = reqwrap;
 }
@@ -40,10 +39,10 @@ static void iotjs_reqwrap_validate(iotjs_reqwrap_t* reqwrap) {
 }
 
 
-const iotjs_jval_t* iotjs_reqwrap_jcallback(iotjs_reqwrap_t* reqwrap) {
+iotjs_jval_t iotjs_reqwrap_jcallback(iotjs_reqwrap_t* reqwrap) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_reqwrap_t, reqwrap);
   iotjs_reqwrap_validate(reqwrap);
-  return &_this->jcallback;
+  return _this->jcallback;
 }
 
 

--- a/src/iotjs_reqwrap.h
+++ b/src/iotjs_reqwrap.h
@@ -33,12 +33,12 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_reqwrap_t);
 
 
-void iotjs_reqwrap_initialize(iotjs_reqwrap_t* reqwrap,
-                              const iotjs_jval_t* jcallback, uv_req_t* request);
+void iotjs_reqwrap_initialize(iotjs_reqwrap_t* reqwrap, iotjs_jval_t jcallback,
+                              uv_req_t* request);
 void iotjs_reqwrap_destroy(iotjs_reqwrap_t* reqwrap);
 
 // To retrieve javascript callback function object.
-const iotjs_jval_t* iotjs_reqwrap_jcallback(iotjs_reqwrap_t* reqwrap);
+iotjs_jval_t iotjs_reqwrap_jcallback(iotjs_reqwrap_t* reqwrap);
 
 // To retrieve pointer to uv request.
 uv_req_t* iotjs_reqwrap_req(iotjs_reqwrap_t* reqwrap);

--- a/src/modules/iotjs_module_adc.c
+++ b/src/modules/iotjs_module_adc.c
@@ -24,7 +24,7 @@ static JNativeInfoType this_module_native_info = {.free_cb = NULL };
 static iotjs_adc_t* iotjs_adc_instance_from_jval(iotjs_jval_t jadc);
 
 
-static iotjs_adc_t* iotjs_adc_create(const iotjs_jval_t* jadc) {
+static iotjs_adc_t* iotjs_adc_create(const iotjs_jval_t jadc) {
   iotjs_adc_t* adc = IOTJS_ALLOC(iotjs_adc_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_adc_t, adc);
   iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jadc,
@@ -52,7 +52,7 @@ static iotjs_adc_reqwrap_t* iotjs_adc_reqwrap_create(
   iotjs_adc_reqwrap_t* adc_reqwrap = IOTJS_ALLOC(iotjs_adc_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_adc_reqwrap_t, adc_reqwrap);
 
-  iotjs_reqwrap_initialize(&_this->reqwrap, &jcallback, (uv_req_t*)&_this->req);
+  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
 
   _this->req_data.op = op;
   _this->adc_instance = adc;
@@ -80,7 +80,7 @@ static uv_work_t* iotjs_adc_reqwrap_req(THIS) {
 
 static iotjs_jval_t iotjs_adc_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_adc_reqwrap_t, adc_reqwrap);
-  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 
@@ -207,7 +207,7 @@ JHANDLER_FUNCTION(AdcConstructor) {
 
   // Create ADC object
   const iotjs_jval_t jadc = JHANDLER_GET_THIS(object);
-  iotjs_adc_t* adc = iotjs_adc_create(&jadc);
+  iotjs_adc_t* adc = iotjs_adc_create(jadc);
   IOTJS_ASSERT(adc == iotjs_adc_instance_from_jval(jadc));
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_adc_t, adc);
 

--- a/src/modules/iotjs_module_blehcisocket.c
+++ b/src/modules/iotjs_module_blehcisocket.c
@@ -52,7 +52,7 @@ iotjs_blehcisocket_t* iotjs_blehcisocket_create(iotjs_jval_t jble) {
   THIS = IOTJS_ALLOC(iotjs_blehcisocket_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_blehcisocket_t, blehcisocket);
 
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, &jble,
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jble,
                                &this_module_native_info);
 
   iotjs_blehcisocket_initialize(blehcisocket);
@@ -61,8 +61,7 @@ iotjs_blehcisocket_t* iotjs_blehcisocket_create(iotjs_jval_t jble) {
 }
 
 
-iotjs_blehcisocket_t* iotjs_blehcisocket_instance_from_jval(
-    const iotjs_jval_t* jble) {
+iotjs_blehcisocket_t* iotjs_blehcisocket_instance_from_jval(iotjs_jval_t jble) {
   iotjs_jobjectwrap_t* jobjectwrap = iotjs_jobjectwrap_from_jobject(jble);
   return (iotjs_blehcisocket_t*)jobjectwrap;
 }

--- a/src/modules/iotjs_module_blehcisocket.h
+++ b/src/modules/iotjs_module_blehcisocket.h
@@ -59,8 +59,7 @@ typedef struct {
 
 
 iotjs_blehcisocket_t* iotjs_blehcisocket_create(iotjs_jval_t jble);
-iotjs_blehcisocket_t* iotjs_blehcisocket_instance_from_jval(
-    const iotjs_jval_t* jble);
+iotjs_blehcisocket_t* iotjs_blehcisocket_instance_from_jval(iotjs_jval_t jble);
 
 
 void iotjs_blehcisocket_initialize(THIS);

--- a/src/modules/iotjs_module_buffer.c
+++ b/src/modules/iotjs_module_buffer.c
@@ -29,7 +29,7 @@ iotjs_bufferwrap_t* iotjs_bufferwrap_create(const iotjs_jval_t jbuiltin,
   iotjs_bufferwrap_t* bufferwrap = IOTJS_ALLOC(iotjs_bufferwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_bufferwrap_t, bufferwrap);
 
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, &jbuiltin,
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jbuiltin,
                                &this_module_native_info);
   if (length > 0) {
     _this->length = length;

--- a/src/modules/iotjs_module_dns.c
+++ b/src/modules/iotjs_module_dns.c
@@ -29,7 +29,7 @@ iotjs_getaddrinfo_reqwrap_t* iotjs_getaddrinfo_reqwrap_create(
       IOTJS_ALLOC(iotjs_getaddrinfo_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_getaddrinfo_reqwrap_t,
                                      getaddrinfo_reqwrap);
-  iotjs_reqwrap_initialize(&_this->reqwrap, &jcallback, (uv_req_t*)&_this->req);
+  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
   return getaddrinfo_reqwrap;
 }
 
@@ -59,7 +59,7 @@ uv_getaddrinfo_t* iotjs_getaddrinfo_reqwrap_req(THIS) {
 iotjs_jval_t iotjs_getaddrinfo_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_getaddrinfo_reqwrap_t,
                                 getaddrinfo_reqwrap);
-  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 #undef THIS

--- a/src/modules/iotjs_module_fs.c
+++ b/src/modules/iotjs_module_fs.c
@@ -29,7 +29,7 @@ typedef struct {
 
 iotjs_fs_reqwrap_t* iotjs_fs_reqwrap_create(const iotjs_jval_t jcallback) {
   iotjs_fs_reqwrap_t* fs_reqwrap = IOTJS_ALLOC(iotjs_fs_reqwrap_t);
-  iotjs_reqwrap_initialize(&fs_reqwrap->reqwrap, &jcallback,
+  iotjs_reqwrap_initialize(&fs_reqwrap->reqwrap, jcallback,
                            (uv_req_t*)&fs_reqwrap->req);
   return fs_reqwrap;
 }
@@ -49,7 +49,7 @@ static void AfterAsync(uv_fs_t* req) {
   IOTJS_ASSERT(req_wrap != NULL);
   IOTJS_ASSERT(&req_wrap->req == req);
 
-  const iotjs_jval_t cb = *iotjs_reqwrap_jcallback(&req_wrap->reqwrap);
+  const iotjs_jval_t cb = iotjs_reqwrap_jcallback(&req_wrap->reqwrap);
   IOTJS_ASSERT(iotjs_jval_is_function(cb));
 
   iotjs_jargs_t jarg = iotjs_jargs_create(2);

--- a/src/modules/iotjs_module_httpparser.c
+++ b/src/modules/iotjs_module_httpparser.c
@@ -79,7 +79,7 @@ static void iotjs_httpparserwrap_create(const iotjs_jval_t jparser,
                                         http_parser_type type) {
   iotjs_httpparserwrap_t* httpparserwrap = IOTJS_ALLOC(iotjs_httpparserwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_httpparserwrap_t, httpparserwrap);
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, &jparser,
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jparser,
                                &this_module_native_info);
 
   _this->url = iotjs_string_create();

--- a/src/modules/iotjs_module_i2c.c
+++ b/src/modules/iotjs_module_i2c.c
@@ -33,7 +33,7 @@ static iotjs_i2c_t* iotjs_i2c_create(iotjs_jhandler_t* jhandler,
   iotjs_i2c_t* i2c = IOTJS_ALLOC(iotjs_i2c_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_i2c_t, i2c);
   i2c_create_platform_data(jhandler, i2c, &_this->platform_data);
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, &ji2c,
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, ji2c,
                                &this_module_native_info);
   return i2c;
 }
@@ -43,7 +43,7 @@ static iotjs_i2c_reqwrap_t* iotjs_i2c_reqwrap_create(
   iotjs_i2c_reqwrap_t* i2c_reqwrap = IOTJS_ALLOC(iotjs_i2c_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_i2c_reqwrap_t, i2c_reqwrap);
 
-  iotjs_reqwrap_initialize(&_this->reqwrap, &jcallback, (uv_req_t*)&_this->req);
+  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
 
   _this->req_data.op = op;
   _this->i2c_data = i2c;
@@ -68,7 +68,7 @@ uv_work_t* iotjs_i2c_reqwrap_req(THIS) {
 
 iotjs_jval_t iotjs_i2c_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_i2c_reqwrap_t, i2c_reqwrap);
-  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 iotjs_i2c_reqwrap_t* iotjs_i2c_reqwrap_from_request(uv_work_t* req) {
@@ -93,7 +93,7 @@ static void iotjs_i2c_destroy(iotjs_i2c_t* i2c) {
   IOTJS_RELEASE(i2c);
 }
 
-iotjs_i2c_t* iotjs_i2c_instance_from_jval(const iotjs_jval_t* ji2c) {
+iotjs_i2c_t* iotjs_i2c_instance_from_jval(const iotjs_jval_t ji2c) {
   iotjs_jobjectwrap_t* jobjectwrap = iotjs_jobjectwrap_from_jobject(ji2c);
   return (iotjs_i2c_t*)jobjectwrap;
 }

--- a/src/modules/iotjs_module_i2c.h
+++ b/src/modules/iotjs_module_i2c.h
@@ -64,7 +64,7 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_i2c_reqwrap_t);
 
 
-iotjs_i2c_t* iotjs_i2c_instance_from_jval(const iotjs_jval_t* ji2c);
+iotjs_i2c_t* iotjs_i2c_instance_from_jval(iotjs_jval_t ji2c);
 iotjs_i2c_reqwrap_t* iotjs_i2c_reqwrap_from_request(uv_work_t* req);
 #define THIS iotjs_i2c_reqwrap_t* i2c_reqwrap
 void iotjs_i2c_reqwrap_dispatched(THIS);

--- a/src/modules/iotjs_module_pwm.c
+++ b/src/modules/iotjs_module_pwm.c
@@ -22,7 +22,7 @@ static iotjs_pwm_t* iotjs_pwm_instance_from_jval(iotjs_jval_t jpwm);
 IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(pwm);
 
 
-static iotjs_pwm_t* iotjs_pwm_create(const iotjs_jval_t* jpwm) {
+static iotjs_pwm_t* iotjs_pwm_create(iotjs_jval_t jpwm) {
   iotjs_pwm_t* pwm = IOTJS_ALLOC(iotjs_pwm_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_pwm_t, pwm);
   iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jpwm,
@@ -50,8 +50,9 @@ static void iotjs_pwm_destroy(iotjs_pwm_t* pwm) {
 #define THIS iotjs_pwm_reqwrap_t* pwm_reqwrap
 
 
-static iotjs_pwm_reqwrap_t* iotjs_pwm_reqwrap_create(
-    const iotjs_jval_t* jcallback, iotjs_pwm_t* pwm, PwmOp op) {
+static iotjs_pwm_reqwrap_t* iotjs_pwm_reqwrap_create(iotjs_jval_t jcallback,
+                                                     iotjs_pwm_t* pwm,
+                                                     PwmOp op) {
   iotjs_pwm_reqwrap_t* pwm_reqwrap = IOTJS_ALLOC(iotjs_pwm_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_pwm_reqwrap_t, pwm_reqwrap);
 
@@ -86,7 +87,7 @@ static uv_work_t* iotjs_pwm_reqwrap_req(THIS) {
 
 static iotjs_jval_t iotjs_pwm_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_pwm_reqwrap_t, pwm_reqwrap);
-  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 
@@ -252,7 +253,7 @@ JHANDLER_FUNCTION(PWMConstructor) {
 
   // Create PWM object
   iotjs_jval_t jpwm = JHANDLER_GET_THIS(object);
-  iotjs_pwm_t* pwm = iotjs_pwm_create(&jpwm);
+  iotjs_pwm_t* pwm = iotjs_pwm_create(jpwm);
   IOTJS_ASSERT(pwm == iotjs_pwm_instance_from_jval(jpwm));
 
   iotjs_jval_t jconfiguration = JHANDLER_GET_ARG(0, object);
@@ -261,7 +262,7 @@ JHANDLER_FUNCTION(PWMConstructor) {
   // Set configuration
   iotjs_pwm_set_configuration(jconfiguration, pwm);
 
-  PWM_ASYNC(open, pwm, &jcallback, kPwmOpOpen);
+  PWM_ASYNC(open, pwm, jcallback, kPwmOpOpen);
 }
 
 
@@ -277,7 +278,7 @@ JHANDLER_FUNCTION(SetPeriod) {
   _this->period = JHANDLER_GET_ARG(0, number);
 
   if (!jerry_value_is_null(jcallback)) {
-    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_period, pwm, &jcallback,
+    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_period, pwm, jcallback,
                             kPwmOpSetPeriod);
   } else {
     if (!iotjs_pwm_set_period(pwm)) {
@@ -301,7 +302,7 @@ JHANDLER_FUNCTION(SetDutyCycle) {
   _this->duty_cycle = JHANDLER_GET_ARG(0, number);
 
   if (!jerry_value_is_null(jcallback)) {
-    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_dutycycle, pwm, &jcallback,
+    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_dutycycle, pwm, jcallback,
                             kPwmOpSetDutyCycle);
   } else {
     if (!iotjs_pwm_set_dutycycle(pwm)) {
@@ -325,7 +326,7 @@ JHANDLER_FUNCTION(SetEnable) {
   _this->enable = JHANDLER_GET_ARG(0, boolean);
 
   if (!jerry_value_is_null(jcallback)) {
-    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_enable, pwm, &jcallback,
+    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_set_enable, pwm, jcallback,
                             kPwmOpSetEnable);
   } else {
     if (!iotjs_pwm_set_enable(pwm)) {
@@ -344,7 +345,7 @@ JHANDLER_FUNCTION(Close) {
   const iotjs_jval_t jcallback = JHANDLER_GET_ARG_IF_EXIST(0, function);
 
   if (!jerry_value_is_null(jcallback)) {
-    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_close, pwm, &jcallback, kPwmOpClose);
+    PWM_ASYNC_COMMON_WORKER(iotjs_pwm_close, pwm, jcallback, kPwmOpClose);
   } else {
     if (!iotjs_pwm_close(pwm)) {
       JHANDLER_THROW(COMMON, "PWM Close Error");

--- a/src/modules/iotjs_module_spi.c
+++ b/src/modules/iotjs_module_spi.c
@@ -25,7 +25,7 @@ IOTJS_DEFINE_NATIVE_HANDLE_INFO_THIS_MODULE(spi);
 static iotjs_spi_t* iotjs_spi_create(iotjs_jval_t jspi) {
   iotjs_spi_t* spi = IOTJS_ALLOC(iotjs_spi_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_spi_t, spi);
-  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, &jspi,
+  iotjs_jobjectwrap_initialize(&_this->jobjectwrap, jspi,
                                &this_module_native_info);
 
 #if defined(__linux__)
@@ -57,7 +57,7 @@ static iotjs_spi_reqwrap_t* iotjs_spi_reqwrap_create(iotjs_jval_t jcallback,
   iotjs_spi_reqwrap_t* spi_reqwrap = IOTJS_ALLOC(iotjs_spi_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_spi_reqwrap_t, spi_reqwrap);
 
-  iotjs_reqwrap_initialize(&_this->reqwrap, &jcallback, (uv_req_t*)&_this->req);
+  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
 
   _this->req_data.op = op;
   _this->spi_instance = spi;
@@ -87,7 +87,7 @@ static uv_work_t* iotjs_spi_reqwrap_req(THIS) {
 
 static iotjs_jval_t iotjs_spi_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_spi_reqwrap_t, spi_reqwrap);
-  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 

--- a/src/modules/iotjs_module_tcp.c
+++ b/src/modules/iotjs_module_tcp.c
@@ -81,8 +81,7 @@ iotjs_jval_t iotjs_tcpwrap_jobject(iotjs_tcpwrap_t* tcpwrap) {
 static void iotjs_connect_reqwrap_destroy(THIS);
 
 
-iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(
-    const iotjs_jval_t* jcallback) {
+iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(iotjs_jval_t jcallback) {
   iotjs_connect_reqwrap_t* connect_reqwrap =
       IOTJS_ALLOC(iotjs_connect_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_connect_reqwrap_t, connect_reqwrap);
@@ -113,7 +112,7 @@ uv_connect_t* iotjs_connect_reqwrap_req(THIS) {
 
 iotjs_jval_t iotjs_connect_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_connect_reqwrap_t, connect_reqwrap);
-  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 #undef THIS
@@ -138,7 +137,7 @@ static void iotjs_write_reqwrap_destroy(THIS);
 iotjs_write_reqwrap_t* iotjs_write_reqwrap_create(iotjs_jval_t jcallback) {
   iotjs_write_reqwrap_t* write_reqwrap = IOTJS_ALLOC(iotjs_write_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_write_reqwrap_t, write_reqwrap);
-  iotjs_reqwrap_initialize(&_this->reqwrap, &jcallback, (uv_req_t*)&_this->req);
+  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
   return write_reqwrap;
 }
 
@@ -165,7 +164,7 @@ uv_write_t* iotjs_write_reqwrap_req(THIS) {
 
 iotjs_jval_t iotjs_write_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_write_reqwrap_t, write_reqwrap);
-  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 #undef THIS
@@ -183,7 +182,7 @@ iotjs_shutdown_reqwrap_t* iotjs_shutdown_reqwrap_create(
       IOTJS_ALLOC(iotjs_shutdown_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_shutdown_reqwrap_t,
                                      shutdown_reqwrap);
-  iotjs_reqwrap_initialize(&_this->reqwrap, &jcallback, (uv_req_t*)&_this->req);
+  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
   return shutdown_reqwrap;
 }
 
@@ -210,7 +209,7 @@ uv_shutdown_t* iotjs_shutdown_reqwrap_req(THIS) {
 
 iotjs_jval_t iotjs_shutdown_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_shutdown_reqwrap_t, shutdown_reqwrap);
-  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 #undef THIS
@@ -327,7 +326,7 @@ JHANDLER_FUNCTION(Connect) {
 
   if (err == 0) {
     // Create connection request wrapper.
-    iotjs_connect_reqwrap_t* req_wrap = iotjs_connect_reqwrap_create(&jcallback);
+    iotjs_connect_reqwrap_t* req_wrap = iotjs_connect_reqwrap_create(jcallback);
 
     // Create connection request.
     err = uv_tcp_connect(iotjs_connect_reqwrap_req(req_wrap),

--- a/src/modules/iotjs_module_tcp.h
+++ b/src/modules/iotjs_module_tcp.h
@@ -50,8 +50,7 @@ typedef struct {
 } IOTJS_VALIDATED_STRUCT(iotjs_connect_reqwrap_t);
 
 #define THIS iotjs_connect_reqwrap_t* connect_reqwrap
-iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(
-    const iotjs_jval_t* jcallback);
+iotjs_connect_reqwrap_t* iotjs_connect_reqwrap_create(iotjs_jval_t jcallback);
 void iotjs_connect_reqwrap_dispatched(THIS);
 uv_connect_t* iotjs_connect_reqwrap_req(THIS);
 iotjs_jval_t iotjs_connect_reqwrap_jcallback(THIS);

--- a/src/modules/iotjs_module_uart.c
+++ b/src/modules/iotjs_module_uart.c
@@ -51,7 +51,7 @@ static iotjs_uart_reqwrap_t* iotjs_uart_reqwrap_create(
   iotjs_uart_reqwrap_t* uart_reqwrap = IOTJS_ALLOC(iotjs_uart_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_uart_reqwrap_t, uart_reqwrap);
 
-  iotjs_reqwrap_initialize(&_this->reqwrap, &jcallback, (uv_req_t*)&_this->req);
+  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
 
   _this->req_data.op = op;
   _this->uart_instance = uart;
@@ -81,7 +81,7 @@ static uv_work_t* iotjs_uart_reqwrap_req(THIS) {
 
 static iotjs_jval_t iotjs_uart_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_uart_reqwrap_t, uart_reqwrap);
-  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 

--- a/src/modules/iotjs_module_udp.c
+++ b/src/modules/iotjs_module_udp.c
@@ -84,7 +84,7 @@ iotjs_send_reqwrap_t* iotjs_send_reqwrap_create(iotjs_jval_t jcallback,
   iotjs_send_reqwrap_t* send_reqwrap = IOTJS_ALLOC(iotjs_send_reqwrap_t);
   IOTJS_VALIDATED_STRUCT_CONSTRUCTOR(iotjs_send_reqwrap_t, send_reqwrap);
 
-  iotjs_reqwrap_initialize(&_this->reqwrap, &jcallback, (uv_req_t*)&_this->req);
+  iotjs_reqwrap_initialize(&_this->reqwrap, jcallback, (uv_req_t*)&_this->req);
   _this->msg_size = msg_size;
   _this->req_data = req_data;
 
@@ -114,7 +114,7 @@ uv_udp_send_t* iotjs_send_reqwrap_req(THIS) {
 
 iotjs_jval_t iotjs_send_reqwrap_jcallback(THIS) {
   IOTJS_VALIDATED_STRUCT_METHOD(iotjs_send_reqwrap_t, send_reqwrap);
-  return *iotjs_reqwrap_jcallback(&_this->reqwrap);
+  return iotjs_reqwrap_jcallback(&_this->reqwrap);
 }
 
 


### PR DESCRIPTION
Removed 'iotjs_jval_t' pointer from 'iotjs_reqwrap' and 'iotjs_objectwrap'.

IoT.js-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com