### PR TITLE
Replace iotjs_buffer_release to IOTJS_RELEASE (#1281)

### DIFF
--- a/src/platform/linux/iotjs_module_gpio-linux.c
+++ b/src/platform/linux/iotjs_module_gpio-linux.c
@@ -210,7 +210,7 @@ void iotjs_gpio_platform_create(iotjs_gpio_t_impl_t* _this) {
 
 
 void iotjs_gpio_platform_destroy(iotjs_gpio_t_impl_t* _this) {
-  iotjs_buffer_release((char*)_this->platform);
+  IOTJS_RELEASE(_this->platform);
 }
 
 

--- a/src/platform/tizen/iotjs_module_gpio-tizen.c
+++ b/src/platform/tizen/iotjs_module_gpio-tizen.c
@@ -28,7 +28,7 @@ void iotjs_gpio_platform_create(iotjs_gpio_t_impl_t* _this) {
 }
 
 void iotjs_gpio_platform_destroy(iotjs_gpio_t_impl_t* _this) {
-  iotjs_buffer_release((char*)_this->platform);
+  IOTJS_RELEASE(_this->platform);
 }
 
 bool iotjs_gpio_write(iotjs_gpio_t* gpio, bool value) {

--- a/src/platform/tizenrt/iotjs_module_gpio-tizenrt.c
+++ b/src/platform/tizenrt/iotjs_module_gpio-tizenrt.c
@@ -31,7 +31,7 @@ void iotjs_gpio_platform_create(iotjs_gpio_t_impl_t* _this) {
 
 
 void iotjs_gpio_platform_destroy(iotjs_gpio_t_impl_t* _this) {
-  iotjs_buffer_release((char*)_this->platform);
+  IOTJS_RELEASE(_this->platform);
 }
 
 


### PR DESCRIPTION
changed for code consistency
reflect the comment of glistening in #1280

IoT.js-DCO-1.0-Signed-off-by: Hosung Kim hs852.kim@samsung.com