### PR TITLE
console.log will print array with enclosing brackets (#1303)

### DIFF
--- a/src/js/util.js
+++ b/src/js/util.js
@@ -146,7 +146,9 @@ function formatValue(v) {
     return 'undefined';
   } else if (v === null) {
     return 'null';
-  } else if (Array.isArray(v) || v instanceof Error) {
+  } else if (Array.isArray(v)) {
+    return '[' + v.toString() + ']';
+  } else if (v instanceof Error) {
     return v.toString();
   } else if (typeof v === 'object') {
     return JSON.stringify(v, null, 2);


### PR DESCRIPTION
Let a = [1,2,3], currently console.log(a) prints

1,2,3

it would be better to print

[1,2,3]

IoT.js-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com